### PR TITLE
Fix SignalRW and combobox width

### DIFF
--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -479,9 +479,12 @@
           "default": null
         },
         "read_pv": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "PV to be used for read, empty means use pv",
-          "default": ""
+          "default": null
         },
         "read_widget": {
           "anyOf": [
@@ -492,12 +495,8 @@
               "type": "null"
             }
           ],
-          "description": "Widget to use for display, default TextRead",
-          "default": {
-            "type": "TextRead",
-            "lines": 1,
-            "format": null
-          }
+          "description": "Widget to use for display, default TextRead.",
+          "default": null
         }
       },
       "required": [

--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -492,8 +492,12 @@
               "type": "null"
             }
           ],
-          "description": "Widget to use for display, None means use widget",
-          "default": null
+          "description": "Widget to use for display, default TextRead",
+          "default": {
+            "type": "TextRead",
+            "lines": 1,
+            "format": null
+          }
         }
       },
       "required": [

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -27,6 +27,7 @@ from pvi._format.widget import (
 from pvi._schema_utils import desc
 from pvi.device import (
     ButtonPanel,
+    ComboBox,
     Component,
     DeviceRef,
     Generic,
@@ -393,7 +394,7 @@ class ScreenFormatterFactory(Generic[T]):
     ) -> Iterator[WidgetFormatter[T]]:
         """Convert a component into its WidgetFormatter equivalents
 
-        Args:
+        Args :
             c: Component object
             bounds: The size and position of the component widgets (x,y,w,h).
             add_label: Whether the component has an associated label. Defaults to True.
@@ -443,7 +444,9 @@ class ScreenFormatterFactory(Generic[T]):
             row_components = [
                 SignalX(label, c.pv, value) for label, value in c.widget.actions.items()
             ]
+
             if isinstance(c, SignalRW):
+                assert c.read_pv
                 row_components += [SignalR(c.label, c.read_pv, c.read_widget)]
         else:
             row_components = [c]  # Create one widget for row
@@ -481,9 +484,12 @@ class ScreenFormatterFactory(Generic[T]):
         )
         for rc_bounds, rc in zip(row_component_bounds, row_components):
             if isinstance(rc, SignalRW):
-                left, right = rc_bounds.split_into(2, self.layout.spacing)
-                yield from self.generate_write_widget(rc, left)
-                yield from self.generate_read_widget(rc, right)
+                if isinstance(rc.widget, ComboBox) or not rc.read_widget:
+                    yield from self.generate_write_widget(rc, rc_bounds)
+                else:
+                    left, right = rc_bounds.split_into(2, self.layout.spacing)
+                    yield from self.generate_write_widget(rc, left)
+                    yield from self.generate_read_widget(rc, right)
             elif isinstance(rc, SignalW):
                 yield from self.generate_write_widget(rc, rc_bounds)
             elif isinstance(rc, SignalR):
@@ -519,6 +525,8 @@ class ScreenFormatterFactory(Generic[T]):
         else:
             widget = signal.widget
             pv = signal.pv
+
+        assert pv
 
         if widget is not None:
             yield self.widget_formatter_factory.pv_widget_formatter(

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -282,18 +282,15 @@ class SignalRW(Component):
         Optional[str], desc("PV to be used for read, empty means use pv")
     ] = None
     read_widget: Annotated[
-        Optional[ReadWidget], desc(
-            "Widget to use for display, default TextRead."
-        )
+        Optional[ReadWidget], desc("Widget to use for display, default TextRead.")
     ] = None
 
     def __post_init__(self):
         if self.read_widget is None:
             self.read_widget = TextRead()
 
-        if (
-            isinstance(self.widget, TextWrite) and
-            isinstance(self.read_widget, TextRead)
+        if isinstance(self.widget, TextWrite) and isinstance(
+            self.read_widget, TextRead
         ):
             self.read_widget.format = self.widget.format
 

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -278,10 +278,27 @@ class SignalRW(Component):
         desc("Widget to use for control, None means don't display"),
     ] = None
     # This was Optional[str] but produced JSON schema that YAML editor didn't understand
-    read_pv: Annotated[str, desc("PV to be used for read, empty means use pv")] = ""
-    read_widget: Annotated[
-        Optional[ReadWidget], desc("Widget to use for display, None means use widget")
+    read_pv: Annotated[
+        Optional[str], desc("PV to be used for read, empty means use pv")
     ] = None
+    read_widget: Annotated[
+        Optional[ReadWidget], desc(
+            "Widget to use for display, default TextRead."
+        )
+    ] = None
+
+    def __post_init__(self):
+        if self.read_widget is None:
+            self.read_widget = TextRead()
+
+        if (
+            isinstance(self.widget, TextWrite) and
+            isinstance(self.read_widget, TextRead)
+        ):
+            self.read_widget.format = self.widget.format
+
+        if not self.read_pv:
+            self.read_pv = self.pv
 
 
 SignalTypes = (SignalR, SignalW, SignalRW)

--- a/tests/convert/output/simDetector.pvi.device.yaml
+++ b/tests/convert/output/simDetector.pvi.device.yaml
@@ -14,6 +14,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: GainY
@@ -21,6 +23,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: GainRed
@@ -28,6 +32,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainRed_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: GainGreen
@@ -35,6 +41,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainGreen_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: GainBlue
@@ -42,6 +50,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainBlue_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: Reset
@@ -49,6 +59,8 @@ children:
     widget:
       type: TextWrite
     read_pv: Reset_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: Offset
@@ -56,6 +68,8 @@ children:
     widget:
       type: TextWrite
     read_pv: Offset_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: Noise
@@ -63,6 +77,8 @@ children:
     widget:
       type: TextWrite
     read_pv: Noise_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: SimMode
@@ -70,6 +86,8 @@ children:
     widget:
       type: ComboBox
     read_pv: SimMode_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakStartX
@@ -77,6 +95,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStartX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakStartY
@@ -84,6 +104,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStartY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakNumX
@@ -91,6 +113,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakNumX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakNumY
@@ -98,6 +122,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakNumY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakStepX
@@ -105,6 +131,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStepX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakStepY
@@ -112,6 +140,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStepY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakWidthX
@@ -119,6 +149,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakWidthX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakWidthY
@@ -126,6 +158,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakWidthY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakVariation
@@ -133,6 +167,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakVariation_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSineOperation
@@ -140,6 +176,8 @@ children:
     widget:
       type: ComboBox
     read_pv: XSineOperation_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine1Amplitude
@@ -147,6 +185,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Amplitude_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine1Frequency
@@ -154,6 +194,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Frequency_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine1Phase
@@ -161,6 +203,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Phase_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine2Amplitude
@@ -168,6 +212,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Amplitude_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine2Frequency
@@ -175,6 +221,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Frequency_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine2Phase
@@ -182,6 +230,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Phase_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSineOperation
@@ -189,6 +239,8 @@ children:
     widget:
       type: ComboBox
     read_pv: YSineOperation_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine1Amplitude
@@ -196,6 +248,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Amplitude_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine1Frequency
@@ -203,6 +257,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Frequency_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine1Phase
@@ -210,6 +266,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Phase_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine2Amplitude
@@ -217,6 +275,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Amplitude_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine2Frequency
@@ -224,6 +284,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Frequency_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine2Phase
@@ -231,3 +293,5 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Phase_RBV
+    read_widget:
+      type: TextRead

--- a/tests/convert/output/simDetector.pvi.device.yaml
+++ b/tests/convert/output/simDetector.pvi.device.yaml
@@ -14,8 +14,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: GainY
@@ -23,8 +21,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: GainRed
@@ -32,8 +28,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainRed_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: GainGreen
@@ -41,8 +35,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainGreen_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: GainBlue
@@ -50,8 +42,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainBlue_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: Reset
@@ -59,8 +49,6 @@ children:
     widget:
       type: TextWrite
     read_pv: Reset_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: Offset
@@ -68,8 +56,6 @@ children:
     widget:
       type: TextWrite
     read_pv: Offset_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: Noise
@@ -77,8 +63,6 @@ children:
     widget:
       type: TextWrite
     read_pv: Noise_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: SimMode
@@ -86,8 +70,6 @@ children:
     widget:
       type: ComboBox
     read_pv: SimMode_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakStartX
@@ -95,8 +77,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStartX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakStartY
@@ -104,8 +84,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStartY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakNumX
@@ -113,8 +91,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakNumX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakNumY
@@ -122,8 +98,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakNumY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakStepX
@@ -131,8 +105,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStepX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakStepY
@@ -140,8 +112,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStepY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakWidthX
@@ -149,8 +119,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakWidthX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakWidthY
@@ -158,8 +126,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakWidthY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakVariation
@@ -167,8 +133,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakVariation_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSineOperation
@@ -176,8 +140,6 @@ children:
     widget:
       type: ComboBox
     read_pv: XSineOperation_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine1Amplitude
@@ -185,8 +147,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Amplitude_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine1Frequency
@@ -194,8 +154,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Frequency_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine1Phase
@@ -203,8 +161,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Phase_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine2Amplitude
@@ -212,8 +168,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Amplitude_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine2Frequency
@@ -221,8 +175,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Frequency_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine2Phase
@@ -230,8 +182,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Phase_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSineOperation
@@ -239,8 +189,6 @@ children:
     widget:
       type: ComboBox
     read_pv: YSineOperation_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine1Amplitude
@@ -248,8 +196,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Amplitude_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine1Frequency
@@ -257,8 +203,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Frequency_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine1Phase
@@ -266,8 +210,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Phase_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine2Amplitude
@@ -275,8 +217,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Amplitude_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine2Frequency
@@ -284,8 +224,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Frequency_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine2Phase
@@ -293,5 +231,3 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Phase_RBV
-    read_widget:
-      type: TextRead

--- a/tests/format/output/mixedWidgets.adl
+++ b/tests/format/output/mixedWidgets.adl
@@ -1636,28 +1636,13 @@ menu {
 	object {
 		x=880
 		y=160
-		width=50
+		width=105
 		height=20
 	}
 	control {
 		chan="$(P)$(R)GapFill"
 		clr=14
 		bclr=51
-	}
-}
-"text update" {
-	object {
-		x=935
-		y=160
-		width=50
-		height=20
-	}
-	monitor {
-		chan="$(P)$(R)GapFill_RBV"
-		clr=54
-		bclr=4
-	}
-	limits {
 	}
 }
 text {

--- a/tests/format/output/mixedWidgets.bob
+++ b/tests/format/output/mixedWidgets.bob
@@ -979,21 +979,8 @@
       <pv_name>$(P)$(R)GapFill</pv_name>
       <x>124</x>
       <y>96</y>
-      <width>60</width>
+      <width>124</width>
       <height>20</height>
-    </widget>
-    <widget type="textupdate" version="2.0.0">
-      <name>TextUpdate</name>
-      <pv_name>$(P)$(R)GapFill_RBV</pv_name>
-      <x>188</x>
-      <y>96</y>
-      <width>60</width>
-      <height>20</height>
-      <font>
-        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
-      </font>
-      </font>
-      <horizontal_alignment>1</horizontal_alignment>
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>

--- a/tests/format/output/mixedWidgets.edl
+++ b/tests/format/output/mixedWidgets.edl
@@ -2076,7 +2076,7 @@ minor 0
 release 0
 x 390
 y 590
-w 60
+w 125
 h 20
 fgColor index 25
 bgColor index 3
@@ -2085,25 +2085,6 @@ topShadowColor index 1
 botShadowColor index 11
 controlPv "$(P)$(R)GapFill"
 font "arial-bold-r-12.0"
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 455
-y 590
-w 60
-h 20
-controlPv "$(P)$(R)GapFill_RBV"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-12.0"
-fontAlign "center"
 endObjectProperties
 
 # (Static Text)

--- a/tests/test_device_serialization.pvi.yaml
+++ b/tests/test_device_serialization.pvi.yaml
@@ -2,35 +2,35 @@
 label: label
 parent: parent
 children:
-- type: Group
-  name: Parameters
-  layout:
-    type: Grid
-  children:
-    - type: SignalRW
-      name: WidthUnits
-      pv: WIDTH:UNITS
-      widget:
-        type: ComboBox
-    - type: SignalRW
-      name: Width
-      pv: WIDTH
-      widget:
-        type: TextWrite
-      read_pv: WIDTH_RBV
-      read_widget:
-        type: TextRead
-- type: SignalRW
-  name: Table
-  pv: TABLE
-  widget:
-    type: TableWrite
-    widgets:
-      - type: CheckBox
-      - type: ComboBox
-      - type: TextWrite
-- type: SignalR
-  name: OutA
-  pv: OUTA
-  widget:
-    type: LED
+  - type: Group
+    name: Parameters
+    layout:
+      type: Grid
+    children:
+      - type: SignalRW
+        name: WidthUnits
+        pv: WIDTH:UNITS
+        widget:
+          type: ComboBox
+        read_pv: WIDTH:UNITS.RBV
+      - type: SignalRW
+        name: Width
+        pv: WIDTH
+        widget:
+          type: TextWrite
+        read_pv: WIDTH_RBV
+  - type: SignalRW
+    name: Table
+    pv: TABLE
+    widget:
+      type: TableWrite
+      widgets:
+        - type: CheckBox
+        - type: ComboBox
+        - type: TextWrite
+    read_pv: TABLE.RBV
+  - type: SignalR
+    name: OutA
+    pv: OUTA
+    widget:
+      type: LED

--- a/tests/test_device_serialization.pvi.yaml
+++ b/tests/test_device_serialization.pvi.yaml
@@ -12,13 +12,17 @@ children:
         pv: WIDTH:UNITS
         widget:
           type: ComboBox
-        read_pv: WIDTH:UNITS.RBV
+        read_pv: WIDTH:UNITS
+        read_widget:
+          type: TextRead
       - type: SignalRW
         name: Width
         pv: WIDTH
         widget:
           type: TextWrite
         read_pv: WIDTH_RBV
+        read_widget:
+          type: TextRead
   - type: SignalRW
     name: Table
     pv: TABLE
@@ -28,7 +32,9 @@ children:
         - type: CheckBox
         - type: ComboBox
         - type: TextWrite
-    read_pv: TABLE.RBV
+    read_pv: TABLE
+    read_widget:
+      type: TextRead
   - type: SignalR
     name: OutA
     pv: OUTA


### PR DESCRIPTION
Closes #41 

* If a `SignalRW` is used for a `ComboBox` the `read_pv` will not be displayed, only the `ComboBox` with no splitting.
* In a `SignalRW`, if a `read_pv` is not provided, the `read_pv` will be the same as the write `pv`.