### PR TITLE
Fix rbv and writewidgets

### DIFF
--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -479,9 +479,12 @@
           "default": null
         },
         "read_pv": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "PV to be used for read, empty means use pv",
-          "default": ""
+          "default": null
         },
         "read_widget": {
           "anyOf": [
@@ -492,12 +495,8 @@
               "type": "null"
             }
           ],
-          "description": "Widget to use for display, default TextRead",
-          "default": {
-            "type": "TextRead",
-            "lines": 1,
-            "format": null
-          }
+          "description": "Widget to use for display, default TextRead.",
+          "default": null
         }
       },
       "required": [

--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -492,8 +492,12 @@
               "type": "null"
             }
           ],
-          "description": "Widget to use for display, None means use widget",
-          "default": null
+          "description": "Widget to use for display, default TextRead",
+          "default": {
+            "type": "TextRead",
+            "lines": 1,
+            "format": null
+          }
         }
       },
       "required": [

--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -556,11 +556,24 @@
         "pv": {
           "type": "string",
           "description": "Child device PVI PV"
+        },
+        "ui": {
+          "type": "string",
+          "description": "UI file to open for referenced Device"
+        },
+        "macros": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Macro-value pairs for UI file"
         }
       },
       "required": [
         "name",
-        "pv"
+        "pv",
+        "ui",
+        "macros"
       ],
       "additionalProperties": false
     },

--- a/src/pvi/_format/adl.py
+++ b/src/pvi/_format/adl.py
@@ -37,7 +37,7 @@ class AdlTemplate(UITemplate[str]):
             properties["height"] = bounds.h
 
         for item, value in properties.items():
-            if template.startswith('"related display"'):
+            if template.startswith('"related display"') and item == "name":
                 value = f"{value}.adl"  # Must include file extension
 
             # Only need single line

--- a/src/pvi/_format/base.py
+++ b/src/pvi/_format/base.py
@@ -1,8 +1,16 @@
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Annotated, Dict, List
 
-from pvi._schema_utils import as_discriminated_union
-from pvi.device import Device
+from pvi._schema_utils import as_discriminated_union, desc
+from pvi.device import Device, DeviceRef
+
+
+@dataclass
+class IndexEntry:
+    label: Annotated[str, desc("Button label")]
+    file_name: Annotated[str, desc("File name of UI file")]
+    macros: Annotated[Dict[str, str], desc("Macros to launch UI with")]
 
 
 @as_discriminated_union
@@ -10,3 +18,29 @@ from pvi.device import Device
 class Formatter:
     def format(self, device: Device, prefix: str, path: Path):
         raise NotImplementedError(self)
+
+    def format_index(self, label: str, index_entries: List[IndexEntry], path: Path):
+        """Format an index of buttons to open the given UIs.
+
+        Args:
+            label: Title of generated index UI
+            index_entries: Buttons to format on the index UI
+            path: Output path of generated UI
+
+        """
+        self.format(
+            Device(
+                label,
+                children=[
+                    DeviceRef(
+                        index.label,
+                        pv=index.label.upper(),
+                        ui=index.file_name,
+                        macros=index.macros,
+                    )
+                    for index in index_entries
+                ],
+            ),
+            prefix="Index",
+            path=path,
+        )

--- a/src/pvi/_format/bob.py
+++ b/src/pvi/_format/bob.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 from copy import deepcopy
-from typing import List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence
 
 from lxml.etree import ElementBase, SubElement, XMLParser, parse
 
@@ -59,15 +57,20 @@ class BobTemplate(UITemplate[ElementBase]):
         t_copy = deepcopy(template)
         for item, value in properties.items():
             new_text = ""
-            if widget_type == "table" and item == "pv_name":
-                new_text = f"pva://{value}"  # Must include pva prefix
-            elif item == "file":
-                new_text = f"{value}.bob"  # Must include file extension
-            else:
-                new_text = str(value)
+
+            match widget_type, item, value:
+                case "table", "pv_name", pv:
+                    new_text = f"pva://{pv}"  # Must include pva prefix
+                case "action_button", "file", file_name:
+                    new_text = f"{file_name}.bob"  # Must include file extension
+                case "action_button", "macros", dict() as macros:
+                    if macros:
+                        add_button_macros(t_copy, value)
+                case _:
+                    new_text = str(value)
 
             if new_text:
-                replace_text(t_copy, item, new_text)
+                find_element(t_copy, item).text = new_text
 
         # Add additional properties from widget
         match widget_type, widget:
@@ -176,6 +179,20 @@ def add_table_column(
             SubElement(options_element, "option").text = option
 
 
+def add_button_macros(widget_element: ElementBase, macros: Dict[str, str]):
+    """Add action macros to the given element.
+
+    Args:
+        widget_element: Element to add action macros to
+        macros: Macros to add to element
+
+    """
+    action_element = find_element(widget_element, "action")
+    macros_element = SubElement(action_element, "macros")
+    for macro, value in macros.items():
+        SubElement(macros_element, macro).text = value
+
+
 def add_combo_box_items(widget_element: ElementBase, combo_box: ComboBox):
     if not combo_box.choices:
         # Default empty -> get items from pv
@@ -197,10 +214,19 @@ def add_format(element: ElementBase, format: str):
         SubElement(element, "format").text = format
 
 
-def replace_text(element: ElementBase, tag: str, text: str):
-    try:
-        # Iterate tree to find tag and replace text
-        list(element.iter(tag=tag))[0].text = text
-    except IndexError as idx:
-        name = element.find("name").text
-        raise ValueError(f"Failed to locate '{tag}' in {name}") from idx
+def find_element(root_element: ElementBase, tag: str, index: int = 0) -> ElementBase:
+    """Iterate tree to find tag and replace text.
+
+    Args:
+        root_element: Root of tree to search
+        tag: Tag to search for in tree
+        index: Match to return if multiple matches are found
+
+    """
+    match list(root_element.iter(tag=tag)):
+        case []:
+            raise ValueError(
+                f"No matches for '{tag}' in {root_element.find('name').text}"
+            )
+        case matches:
+            return matches[index]

--- a/src/pvi/_format/bob.py
+++ b/src/pvi/_format/bob.py
@@ -8,8 +8,6 @@ from pvi._format.widget import UITemplate, WidgetFormatter
 from pvi.device import (
     LED,
     ComboBox,
-    Group,
-    Row,
     TableRead,
     TableWidgetType,
     TableWrite,
@@ -137,13 +135,6 @@ class BobTemplate(UITemplate[ElementBase]):
         for c in children:
             group_object[0].append(c.format()[0])
         return group_object
-
-
-def is_table(component: Group) -> bool:
-    return all(
-        isinstance(sub_component, Group) and isinstance(sub_component.layout, Row)
-        for sub_component in component.children
-    )
 
 
 def add_table_columns(widget_element: ElementBase, table: TableWidgetType):

--- a/src/pvi/_format/dls.bob
+++ b/src/pvi/_format/dls.bob
@@ -52,13 +52,13 @@
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>ActionButton</name>
+    <name>WritePV</name>
     <pv_name>SignalX</pv_name>
     <actions>
       <action type="write_pv">
         <pv_name>$(pv_name)</pv_name>
         <value>value</value>
-        <description>WritePV</description>
+        <description>$(name)</description>
       </action>
     </actions>
     <text>SignalX</text>
@@ -174,7 +174,7 @@
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>SubScreen</name>
+    <name>OpenDisplay</name>
     <actions>
       <action type="open_display">
         <file>SubScreenFile</file>
@@ -182,7 +182,7 @@
         <description>Open Display</description>
       </action>
     </actions>
-    <text>...</text>
+    <text>SubScreen</text>
     <x>20</x>
     <y>412</y>
     <width>120</width>

--- a/src/pvi/_format/dls.py
+++ b/src/pvi/_format/dls.py
@@ -259,7 +259,7 @@ class DLSFormatter(Formatter):
             sub_screen_formatter_cls=SubScreenWidgetFormatter.from_template(
                 template,
                 search="SubScreen",
-                property_map=dict(file="file_name"),
+                property_map=dict(file="file_name", macros="macros"),
             ),
         )
         # MAKE_WIDGETS DOCS REF: Define screen and group widgets

--- a/src/pvi/_format/dls.py
+++ b/src/pvi/_format/dls.py
@@ -253,13 +253,13 @@ class DLSFormatter(Formatter):
             ),
             action_formatter_cls=ActionWidgetFormatter.from_template(
                 template,
-                search="ActionButton",
+                search="WritePV",
                 property_map=dict(text="label", pv_name="pv", value="value"),
             ),
             sub_screen_formatter_cls=SubScreenWidgetFormatter.from_template(
                 template,
-                search="SubScreen",
-                property_map=dict(file="file_name", macros="macros"),
+                search="OpenDisplay",
+                property_map=dict(file="file_name", text="label", macros="macros"),
             ),
         )
         # MAKE_WIDGETS DOCS REF: Define screen and group widgets

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -29,6 +29,7 @@ from pvi._schema_utils import desc
 from pvi.device import (
     ButtonPanel,
     Component,
+    DeviceRef,
     Generic,
     Grid,
     Group,
@@ -177,6 +178,10 @@ class ScreenFormatterFactory(Generic[T]):
 
         sub_screen_formatters: List[Tuple[str, GroupFormatter[T]]] = []
         for sub_screen_factory in sub_screen_factories:
+            if sub_screen_factory.components is None:
+                # This is a reference to an existing screen - don't create it
+                continue
+
             factory = ScreenFormatterFactory(
                 screen_formatter_cls=self.screen_formatter_cls,
                 group_formatter_cls=self.group_formatter_cls,
@@ -488,11 +493,14 @@ class ScreenFormatterFactory(Generic[T]):
                 )
             elif isinstance(rc, Group) and isinstance(rc.layout, SubScreen):
                 yield self.widget_formatter_factory.sub_screen_formatter_cls(
-                    rc_bounds,
-                    f"{self.base_file_name}_{rc.name}",
-                    rc,
+                    bounds=rc_bounds,
+                    file_name=f"{self.base_file_name}_{rc.name.replace(' ', '_')}",
+                    components=rc,
                 )
-        # TODO: Need to handle DeviceRef
+            elif isinstance(rc, DeviceRef):
+                yield self.widget_formatter_factory.sub_screen_formatter_cls(
+                    bounds=rc_bounds, file_name=rc.ui, macros=rc.macros
+                )
 
     def generate_read_widget(self, signal: ReadSignalType, bounds: Bounds):
         if isinstance(signal, SignalRW):

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -27,6 +27,7 @@ from pvi._format.widget import (
 from pvi._schema_utils import desc
 from pvi.device import (
     ButtonPanel,
+    ComboBox,
     Component,
     DeviceRef,
     Generic,
@@ -393,7 +394,7 @@ class ScreenFormatterFactory(Generic[T]):
     ) -> Iterator[WidgetFormatter[T]]:
         """Convert a component into its WidgetFormatter equivalents
 
-        Args:
+        Args :
             c: Component object
             bounds: The size and position of the component widgets (x,y,w,h).
             add_label: Whether the component has an associated label. Defaults to True.
@@ -443,7 +444,9 @@ class ScreenFormatterFactory(Generic[T]):
             row_components = [
                 SignalX(label, c.pv, value) for label, value in c.widget.actions.items()
             ]
+
             if isinstance(c, SignalRW):
+                assert c.read_pv
                 row_components += [SignalR(c.label, c.read_pv, c.read_widget)]
         else:
             row_components = [c]  # Create one widget for row
@@ -481,9 +484,12 @@ class ScreenFormatterFactory(Generic[T]):
         )
         for rc_bounds, rc in zip(row_component_bounds, row_components):
             if isinstance(rc, SignalRW):
-                left, right = rc_bounds.split_into(2, self.layout.spacing)
-                yield from self.generate_write_widget(rc, left)
-                yield from self.generate_read_widget(rc, right)
+                if isinstance(rc.widget, ComboBox) or not rc.read_widget:
+                    yield from self.generate_write_widget(rc, rc_bounds)
+                else:
+                    left, right = rc_bounds.split_into(2, self.layout.spacing)
+                    yield from self.generate_write_widget(rc, left)
+                    yield from self.generate_read_widget(rc, right)
             elif isinstance(rc, SignalW):
                 yield from self.generate_write_widget(rc, rc_bounds)
             elif isinstance(rc, SignalR):
@@ -519,6 +525,8 @@ class ScreenFormatterFactory(Generic[T]):
         else:
             widget = signal.widget
             pv = signal.pv
+
+        assert pv
 
         if widget is not None:
             yield self.widget_formatter_factory.pv_widget_formatter(

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -236,7 +236,7 @@ class ScreenFormatterFactory(Generic[T]):
                 column_bounds=column_bounds,
                 next_column_bounds=next_column_bounds,
                 indent=True,
-                add_label=True,
+                add_label=False,
             )
 
         group_formatter = self.create_group_formatter(
@@ -498,12 +498,16 @@ class ScreenFormatterFactory(Generic[T]):
             elif isinstance(rc, Group) and isinstance(rc.layout, SubScreen):
                 yield self.widget_formatter_factory.sub_screen_formatter_cls(
                     bounds=rc_bounds,
+                    label=rc.get_label(),
                     file_name=f"{self.base_file_name}_{rc.name.replace(' ', '_')}",
                     components=rc,
                 )
             elif isinstance(rc, DeviceRef):
                 yield self.widget_formatter_factory.sub_screen_formatter_cls(
-                    bounds=rc_bounds, file_name=rc.ui, macros=rc.macros
+                    bounds=rc_bounds,
+                    label=rc.get_label(),
+                    file_name=rc.ui,
+                    macros=rc.macros,
                 )
             else:
                 print(f"Ignoring row component {rc}")

--- a/src/pvi/_format/widget.py
+++ b/src/pvi/_format/widget.py
@@ -157,6 +157,7 @@ class ActionWidgetFormatter(WidgetFormatter[T]):
 
 @dataclass
 class SubScreenWidgetFormatter(WidgetFormatter[T]):
+    label: str
     file_name: str
     components: Optional[Group] = None
     macros: Dict[str, str] = field(default_factory=dict)

--- a/src/pvi/_format/widget.py
+++ b/src/pvi/_format/widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Callable, Dict, List, Optional, Type, TypeVar, Union
 
 from pvi._format.utils import Bounds, GroupType
@@ -158,7 +158,8 @@ class ActionWidgetFormatter(WidgetFormatter[T]):
 @dataclass
 class SubScreenWidgetFormatter(WidgetFormatter[T]):
     file_name: str
-    components: Group
+    components: Optional[Group] = None
+    macros: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -373,6 +373,9 @@ class Device:
     @classmethod
     def deserialize(cls, serialized: Path) -> Device:
         """Deserialize the Device from a YAML file"""
+        if not serialized.is_file():
+            raise FileNotFoundError(serialized)
+
         return deserialize(cls, YAML(typ="safe").load(serialized))
 
     def deserialize_parents(self, yaml_paths: List[Path]):

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -302,6 +302,11 @@ class DeviceRef(Component):
     """Reference to another Device."""
 
     pv: Annotated[str, desc("Child device PVI PV")]
+    ui: Annotated[str, desc("UI file to open for referenced Device")]
+    macros: Annotated[
+        Dict[str, str],
+        desc("Macro-value pairs for UI file"),
+    ] = field(default_factory=dict)
 
 
 class SignalRef(Component):

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -282,18 +282,15 @@ class SignalRW(Component):
         Optional[str], desc("PV to be used for read, empty means use pv")
     ] = None
     read_widget: Annotated[
-        Optional[ReadWidget], desc(
-            "Widget to use for display, default TextRead."
-        )
+        Optional[ReadWidget], desc("Widget to use for display, default TextRead.")
     ] = None
 
     def __post_init__(self):
         if self.read_widget is None:
             self.read_widget = TextRead()
 
-        if (
-            isinstance(self.widget, TextWrite) and
-            isinstance(self.read_widget, TextRead)
+        if isinstance(self.widget, TextWrite) and isinstance(
+            self.read_widget, TextRead
         ):
             self.read_widget.format = self.widget.format
 

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -278,10 +278,27 @@ class SignalRW(Component):
         desc("Widget to use for control, None means don't display"),
     ] = None
     # This was Optional[str] but produced JSON schema that YAML editor didn't understand
-    read_pv: Annotated[str, desc("PV to be used for read, empty means use pv")] = ""
-    read_widget: Annotated[
-        Optional[ReadWidget], desc("Widget to use for display, None means use widget")
+    read_pv: Annotated[
+        Optional[str], desc("PV to be used for read, empty means use pv")
     ] = None
+    read_widget: Annotated[
+        Optional[ReadWidget], desc(
+            "Widget to use for display, default TextRead."
+        )
+    ] = None
+
+    def __post_init__(self):
+        if self.read_widget is None:
+            self.read_widget = TextRead()
+
+        if (
+            isinstance(self.widget, TextWrite) and
+            isinstance(self.read_widget, TextRead)
+        ):
+            self.read_widget.format = self.widget.format
+
+        if not self.read_pv:
+            self.read_pv = self.pv
 
 
 SignalTypes = (SignalR, SignalW, SignalRW)

--- a/tests/convert/output/simDetector.pvi.device.yaml
+++ b/tests/convert/output/simDetector.pvi.device.yaml
@@ -14,6 +14,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: GainY
@@ -21,6 +23,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: GainRed
@@ -28,6 +32,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainRed_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: GainGreen
@@ -35,6 +41,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainGreen_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: GainBlue
@@ -42,6 +50,8 @@ children:
     widget:
       type: TextWrite
     read_pv: GainBlue_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: Reset
@@ -49,6 +59,8 @@ children:
     widget:
       type: TextWrite
     read_pv: Reset_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: Offset
@@ -56,6 +68,8 @@ children:
     widget:
       type: TextWrite
     read_pv: Offset_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: Noise
@@ -63,6 +77,8 @@ children:
     widget:
       type: TextWrite
     read_pv: Noise_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: SimMode
@@ -70,6 +86,8 @@ children:
     widget:
       type: ComboBox
     read_pv: SimMode_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakStartX
@@ -77,6 +95,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStartX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakStartY
@@ -84,6 +104,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStartY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakNumX
@@ -91,6 +113,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakNumX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakNumY
@@ -98,6 +122,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakNumY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakStepX
@@ -105,6 +131,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStepX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakStepY
@@ -112,6 +140,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStepY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakWidthX
@@ -119,6 +149,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakWidthX_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakWidthY
@@ -126,6 +158,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakWidthY_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: PeakVariation
@@ -133,6 +167,8 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakVariation_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSineOperation
@@ -140,6 +176,8 @@ children:
     widget:
       type: ComboBox
     read_pv: XSineOperation_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine1Amplitude
@@ -147,6 +185,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Amplitude_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine1Frequency
@@ -154,6 +194,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Frequency_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine1Phase
@@ -161,6 +203,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Phase_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine2Amplitude
@@ -168,6 +212,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Amplitude_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine2Frequency
@@ -175,6 +221,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Frequency_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: XSine2Phase
@@ -182,6 +230,8 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Phase_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSineOperation
@@ -189,6 +239,8 @@ children:
     widget:
       type: ComboBox
     read_pv: YSineOperation_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine1Amplitude
@@ -196,6 +248,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Amplitude_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine1Frequency
@@ -203,6 +257,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Frequency_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine1Phase
@@ -210,6 +266,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Phase_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine2Amplitude
@@ -217,6 +275,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Amplitude_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine2Frequency
@@ -224,6 +284,8 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Frequency_RBV
+    read_widget:
+      type: TextRead
 
   - type: SignalRW
     name: YSine2Phase
@@ -231,3 +293,5 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Phase_RBV
+    read_widget:
+      type: TextRead

--- a/tests/convert/output/simDetector.pvi.device.yaml
+++ b/tests/convert/output/simDetector.pvi.device.yaml
@@ -14,8 +14,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: GainY
@@ -23,8 +21,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: GainRed
@@ -32,8 +28,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainRed_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: GainGreen
@@ -41,8 +35,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainGreen_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: GainBlue
@@ -50,8 +42,6 @@ children:
     widget:
       type: TextWrite
     read_pv: GainBlue_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: Reset
@@ -59,8 +49,6 @@ children:
     widget:
       type: TextWrite
     read_pv: Reset_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: Offset
@@ -68,8 +56,6 @@ children:
     widget:
       type: TextWrite
     read_pv: Offset_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: Noise
@@ -77,8 +63,6 @@ children:
     widget:
       type: TextWrite
     read_pv: Noise_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: SimMode
@@ -86,8 +70,6 @@ children:
     widget:
       type: ComboBox
     read_pv: SimMode_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakStartX
@@ -95,8 +77,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStartX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakStartY
@@ -104,8 +84,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStartY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakNumX
@@ -113,8 +91,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakNumX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakNumY
@@ -122,8 +98,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakNumY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakStepX
@@ -131,8 +105,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStepX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakStepY
@@ -140,8 +112,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakStepY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakWidthX
@@ -149,8 +119,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakWidthX_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakWidthY
@@ -158,8 +126,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakWidthY_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: PeakVariation
@@ -167,8 +133,6 @@ children:
     widget:
       type: TextWrite
     read_pv: PeakVariation_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSineOperation
@@ -176,8 +140,6 @@ children:
     widget:
       type: ComboBox
     read_pv: XSineOperation_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine1Amplitude
@@ -185,8 +147,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Amplitude_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine1Frequency
@@ -194,8 +154,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Frequency_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine1Phase
@@ -203,8 +161,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine1Phase_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine2Amplitude
@@ -212,8 +168,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Amplitude_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine2Frequency
@@ -221,8 +175,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Frequency_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: XSine2Phase
@@ -230,8 +182,6 @@ children:
     widget:
       type: TextWrite
     read_pv: XSine2Phase_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSineOperation
@@ -239,8 +189,6 @@ children:
     widget:
       type: ComboBox
     read_pv: YSineOperation_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine1Amplitude
@@ -248,8 +196,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Amplitude_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine1Frequency
@@ -257,8 +203,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Frequency_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine1Phase
@@ -266,8 +210,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine1Phase_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine2Amplitude
@@ -275,8 +217,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Amplitude_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine2Frequency
@@ -284,8 +224,6 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Frequency_RBV
-    read_widget:
-      type: TextRead
 
   - type: SignalRW
     name: YSine2Phase
@@ -293,5 +231,3 @@ children:
     widget:
       type: TextWrite
     read_pv: YSine2Phase_RBV
-    read_widget:
-      type: TextRead

--- a/tests/format/output/button.bob
+++ b/tests/format/output/button.bob
@@ -64,13 +64,13 @@
     <height>20</height>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>ActionButton</name>
+    <name>WritePV</name>
     <pv_name>$(P)Acquire</pv_name>
     <actions>
       <action type="write_pv">
         <pv_name>$(pv_name)</pv_name>
         <value>1</value>
-        <description>WritePV</description>
+        <description>$(name)</description>
       </action>
     </actions>
     <text>Start</text>
@@ -81,13 +81,13 @@
     <tooltip>$(actions)</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>ActionButton</name>
+    <name>WritePV</name>
     <pv_name>$(P)Acquire</pv_name>
     <actions>
       <action type="write_pv">
         <pv_name>$(pv_name)</pv_name>
         <value>0</value>
-        <description>WritePV</description>
+        <description>$(name)</description>
       </action>
     </actions>
     <text>Stop</text>
@@ -106,13 +106,13 @@
     <height>20</height>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>ActionButton</name>
+    <name>WritePV</name>
     <pv_name>$(P)Acquire</pv_name>
     <actions>
       <action type="write_pv">
         <pv_name>$(pv_name)</pv_name>
         <value>1</value>
-        <description>WritePV</description>
+        <description>$(name)</description>
       </action>
     </actions>
     <text>Start</text>
@@ -123,13 +123,13 @@
     <tooltip>$(actions)</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>ActionButton</name>
+    <name>WritePV</name>
     <pv_name>$(P)Acquire</pv_name>
     <actions>
       <action type="write_pv">
         <pv_name>$(pv_name)</pv_name>
         <value>0</value>
-        <description>WritePV</description>
+        <description>$(name)</description>
       </action>
     </actions>
     <text>Stop</text>

--- a/tests/format/output/device_ref.bob
+++ b/tests/format/output/device_ref.bob
@@ -1,0 +1,56 @@
+<display version="2.0.0">
+  <name>Display</name>
+  <x>0</x>
+  <y>0</y>
+  <width>274</width>
+  <height>54</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Device - $(P)$(R)</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>274</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Combo Box</text>
+    <x>22</x>
+    <y>30</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
+  <widget type="action_button" version="3.0.0">
+    <name>SubScreen</name>
+    <actions>
+      <action type="open_display">
+        <file>combo_box.bob</file>
+        <target>tab</target>
+        <description>Open Display</description>
+        <macros>
+          <P>EIGER</P>
+          <R>:CAM:</R>
+        </macros>
+      </action>
+    </actions>
+    <text>Combo Box</text>
+    <x>146</x>
+    <y>30</y>
+    <width>124</width>
+    <height>20</height>
+    <tooltip>$(actions)</tooltip>
+  </widget>
+</display>

--- a/tests/format/output/device_ref.bob
+++ b/tests/format/output/device_ref.bob
@@ -34,7 +34,7 @@
     <height>20</height>
   </widget>
   <widget type="action_button" version="3.0.0">
-    <name>SubScreen</name>
+    <name>OpenDisplay</name>
     <actions>
       <action type="open_display">
         <file>combo_box.bob</file>

--- a/tests/format/output/mixedWidgets.adl
+++ b/tests/format/output/mixedWidgets.adl
@@ -1636,28 +1636,13 @@ menu {
 	object {
 		x=880
 		y=160
-		width=50
+		width=105
 		height=20
 	}
 	control {
 		chan="$(P)$(R)GapFill"
 		clr=14
 		bclr=51
-	}
-}
-"text update" {
-	object {
-		x=935
-		y=160
-		width=50
-		height=20
-	}
-	monitor {
-		chan="$(P)$(R)GapFill_RBV"
-		clr=54
-		bclr=4
-	}
-	limits {
 	}
 }
 text {

--- a/tests/format/output/mixedWidgets.bob
+++ b/tests/format/output/mixedWidgets.bob
@@ -979,21 +979,8 @@
       <pv_name>$(P)$(R)GapFill</pv_name>
       <x>124</x>
       <y>96</y>
-      <width>60</width>
+      <width>124</width>
       <height>20</height>
-    </widget>
-    <widget type="textupdate" version="2.0.0">
-      <name>TextUpdate</name>
-      <pv_name>$(P)$(R)GapFill_RBV</pv_name>
-      <x>188</x>
-      <y>96</y>
-      <width>60</width>
-      <height>20</height>
-      <font>
-        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
-      </font>
-      </font>
-      <horizontal_alignment>1</horizontal_alignment>
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>

--- a/tests/format/output/mixedWidgets.edl
+++ b/tests/format/output/mixedWidgets.edl
@@ -2076,7 +2076,7 @@ minor 0
 release 0
 x 390
 y 590
-w 60
+w 125
 h 20
 fgColor index 25
 bgColor index 3
@@ -2085,25 +2085,6 @@ topShadowColor index 1
 botShadowColor index 11
 controlPv "$(P)$(R)GapFill"
 font "arial-bold-r-12.0"
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 455
-y 590
-w 60
-h 20
-controlPv "$(P)$(R)GapFill_RBV"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-12.0"
-fontAlign "center"
 endObjectProperties
 
 # (Static Text)

--- a/tests/format/output/static_table.adl
+++ b/tests/format/output/static_table.adl
@@ -140,10 +140,10 @@ byte {
 }
 "related display" {
 	object {
-		x="4.adl"
-		y="54.adl"
-		width="408.adl"
-		height="20.adl"
+		x=4
+		y=54
+		width=408
+		height=20
 	}
 	display[0] {
 		name="static_table_BigTable.adl"

--- a/tests/format/output/static_table.adl
+++ b/tests/format/output/static_table.adl
@@ -138,24 +138,11 @@ byte {
 	}
 	sbit=0
 }
-text {
-	object {
-		x=4
-		y=54
-		width=150
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Big Table"
-	align="horiz. right"
-}
 "related display" {
 	object {
-		x="158.adl"
+		x="4.adl"
 		y="54.adl"
-		width="254.adl"
+		width="408.adl"
 		height="20.adl"
 	}
 	display[0] {

--- a/tests/format/output/static_table.bob
+++ b/tests/format/output/static_table.bob
@@ -41,16 +41,8 @@
     <width>20</width>
     <height>20</height>
   </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>Big Table</text>
-    <x>22</x>
-    <y>54</y>
-    <width>120</width>
-    <height>20</height>
-  </widget>
   <widget type="action_button" version="3.0.0">
-    <name>SubScreen</name>
+    <name>OpenDisplay</name>
     <actions>
       <action type="open_display">
         <file>static_table_BigTable.bob</file>
@@ -58,10 +50,10 @@
         <description>Open Display</description>
       </action>
     </actions>
-    <text>...</text>
-    <x>146</x>
+    <text>Big Table</text>
+    <x>22</x>
     <y>54</y>
-    <width>124</width>
+    <width>248</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
   </widget>

--- a/tests/format/output/static_table.edl
+++ b/tests/format/output/static_table.edl
@@ -81,34 +81,15 @@ lineWidth 2
 numBits 1
 endObjectProperties
 
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 55
-w 115
-h 20
-font "arial-bold-r-10.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "Big Table"
-}
-endObjectProperties
-
 # (Extended Related Display)
 object ExtendedRelatedDisplayClass
 beginObjectProperties
 major 4
 minor 0
 release 0
-x 130
+x 10
 y 55
-w 125
+w 245
 h 20
 fgColor index 25
 bgColor index 3

--- a/tests/format/output/sub_screen.bob
+++ b/tests/format/output/sub_screen.bob
@@ -46,16 +46,8 @@
     </font>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>Group 1</text>
-    <x>22</x>
-    <y>54</y>
-    <width>120</width>
-    <height>20</height>
-  </widget>
   <widget type="action_button" version="3.0.0">
-    <name>SubScreen</name>
+    <name>OpenDisplay</name>
     <actions>
       <action type="open_display">
         <file>sub_screen_Group_1.bob</file>
@@ -63,10 +55,10 @@
         <description>Open Display</description>
       </action>
     </actions>
-    <text>...</text>
-    <x>146</x>
+    <text>Group 1</text>
+    <x>22</x>
     <y>54</y>
-    <width>124</width>
+    <width>248</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
   </widget>
@@ -107,7 +99,7 @@
       <height>20</height>
     </widget>
     <widget type="action_button" version="3.0.0">
-      <name>SubScreen</name>
+      <name>OpenDisplay</name>
       <actions>
         <action type="open_display">
           <file>sub_screen_Group_4.bob</file>
@@ -115,7 +107,7 @@
           <description>Open Display</description>
         </action>
       </actions>
-      <text>...</text>
+      <text>Group 4</text>
       <x>124</x>
       <y>24</y>
       <width>124</width>

--- a/tests/format/output/sub_screen.bob
+++ b/tests/format/output/sub_screen.bob
@@ -1,0 +1,126 @@
+<display version="2.0.0">
+  <name>Display</name>
+  <x>0</x>
+  <y>0</y>
+  <width>290</width>
+  <height>160</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Device - $(P)$(R)</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>290</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>A</text>
+    <x>22</x>
+    <y>30</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>TextUpdate</name>
+    <pv_name>$(P)$(R)A</pv_name>
+    <x>146</x>
+    <y>30</y>
+    <width>124</width>
+    <height>20</height>
+    <font>
+      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+    </font>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Group 1</text>
+    <x>22</x>
+    <y>54</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
+  <widget type="action_button" version="3.0.0">
+    <name>SubScreen</name>
+    <actions>
+      <action type="open_display">
+        <file>sub_screen_Group_1.bob</file>
+        <target>tab</target>
+        <description>Open Display</description>
+      </action>
+    </actions>
+    <text>...</text>
+    <x>146</x>
+    <y>54</y>
+    <width>124</width>
+    <height>20</height>
+    <tooltip>$(actions)</tooltip>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Group 3</name>
+    <x>4</x>
+    <y>78</y>
+    <width>282</width>
+    <height>78</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Group 3  E</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GROUP3:E</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Group 4</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+    </widget>
+    <widget type="action_button" version="3.0.0">
+      <name>SubScreen</name>
+      <actions>
+        <action type="open_display">
+          <file>sub_screen_Group_4.bob</file>
+          <target>tab</target>
+          <description>Open Display</description>
+        </action>
+      </actions>
+      <text>...</text>
+      <x>124</x>
+      <y>24</y>
+      <width>124</width>
+      <height>20</height>
+      <tooltip>$(actions)</tooltip>
+    </widget>
+  </widget>
+</display>

--- a/tests/format/output/sub_screen_Group_1.bob
+++ b/tests/format/output/sub_screen_Group_1.bob
@@ -1,0 +1,99 @@
+<display version="2.0.0">
+  <name>Display</name>
+  <x>0</x>
+  <y>0</y>
+  <width>290</width>
+  <height>136</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Group 1</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>290</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Group 1  B</text>
+    <x>22</x>
+    <y>30</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>TextUpdate</name>
+    <pv_name>$(P)$(R)GROUP1:B</pv_name>
+    <x>146</x>
+    <y>30</y>
+    <width>124</width>
+    <height>20</height>
+    <font>
+      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+    </font>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Group 2</name>
+    <x>4</x>
+    <y>54</y>
+    <width>282</width>
+    <height>78</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Group 2  C</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GROUP1:GROUP2:C</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Group 2  D</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GROUP1:GROUP2:D</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+</display>

--- a/tests/format/output/sub_screen_Group_4.bob
+++ b/tests/format/output/sub_screen_Group_4.bob
@@ -1,0 +1,99 @@
+<display version="2.0.0">
+  <name>Display</name>
+  <x>0</x>
+  <y>0</y>
+  <width>290</width>
+  <height>136</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Group 4</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>290</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Group 4  F</text>
+    <x>22</x>
+    <y>30</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>TextUpdate</name>
+    <pv_name>$(P)$(R)GROUP3:GROUP4:F</pv_name>
+    <x>146</x>
+    <y>30</y>
+    <width>124</width>
+    <height>20</height>
+    <font>
+      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+    </font>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Group 5</name>
+    <x>4</x>
+    <y>54</y>
+    <width>282</width>
+    <height>78</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Group 5  G</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GROUP3:GROUP4:GROUP5:G</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Group 5  H</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)GROUP3:GROUP4:GROUP5:H</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+</display>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ from pvi.device import (
     ButtonPanel,
     ComboBox,
     Device,
+    DeviceRef,
     SignalR,
     SignalRW,
     SignalW,
@@ -132,6 +133,23 @@ def test_combo_box(tmp_path, helper):
 
     expected_bob = HERE / "format" / "output" / "combo_box.bob"
     output_bob = tmp_path / "combo_box.bob"
+    formatter.format(device, "$(P)$(R)", output_bob)
+
+    helper.assert_output_matches(expected_bob, output_bob)
+
+
+def test_device_ref(tmp_path, helper):
+    formatter_yaml = HERE / "format" / "input" / "dls.bob.pvi.formatter.yaml"
+    formatter = deserialize_yaml(Formatter, formatter_yaml)
+
+    # Make a button to open an existing screen - use screen from combo box test
+    device_ref = DeviceRef(
+        "ComboBox", pv="COMBOBOX", ui="combo_box", macros=dict(P="EIGER", R=":CAM:")
+    )
+    device = Device("Device", children=[device_ref])
+
+    expected_bob = HERE / "format" / "output" / "device_ref.bob"
+    output_bob = tmp_path / "device_ref.bob"
     formatter.format(device, "$(P)$(R)", output_bob)
 
     helper.assert_output_matches(expected_bob, output_bob)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,9 +10,12 @@ from pvi.device import (
     ComboBox,
     Device,
     DeviceRef,
+    Grid,
+    Group,
     SignalR,
     SignalRW,
     SignalW,
+    SubScreen,
     TableRead,
     TableWrite,
     TextFormat,
@@ -150,6 +153,68 @@ def test_device_ref(tmp_path, helper):
 
     expected_bob = HERE / "format" / "output" / "device_ref.bob"
     output_bob = tmp_path / "device_ref.bob"
+    formatter.format(device, "$(P)$(R)", output_bob)
+
+    helper.assert_output_matches(expected_bob, output_bob)
+
+
+def test_group_sub_screen(tmp_path, helper):
+    formatter_yaml = HERE / "format" / "input" / "dls.bob.pvi.formatter.yaml"
+    formatter = deserialize_yaml(Formatter, formatter_yaml)
+
+    # This tests every valid combination of nesting Group and SubScreen
+    signals = [
+        SignalR("A", "A", widget=TextRead()),
+        Group(
+            "Group 1",
+            layout=SubScreen(),
+            children=[
+                SignalR("Group 1 B", "GROUP1:B", widget=TextRead()),
+                Group(
+                    "Group 2",
+                    layout=Grid(),
+                    children=[
+                        SignalR("Group 2 C", "GROUP1:GROUP2:C", widget=TextRead()),
+                        SignalR("Group 2 D", "GROUP1:GROUP2:D", widget=TextRead()),
+                    ],
+                ),
+            ],
+        ),
+        Group(
+            "Group 3",
+            layout=Grid(),
+            children=[
+                SignalR("Group 3 E", "GROUP3:E", widget=TextRead()),
+                Group(
+                    "Group 4",
+                    layout=SubScreen(),
+                    children=[
+                        SignalR("Group 4 F", "GROUP3:GROUP4:F", widget=TextRead()),
+                        Group(
+                            "Group 5",
+                            layout=Grid(),
+                            children=[
+                                SignalR(
+                                    "Group 5 G",
+                                    "GROUP3:GROUP4:GROUP5:G",
+                                    widget=TextRead(),
+                                ),
+                                SignalR(
+                                    "Group 5 H",
+                                    "GROUP3:GROUP4:GROUP5:H",
+                                    widget=TextRead(),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ]
+    device = Device("Device", children=signals)
+
+    expected_bob = HERE / "format" / "output" / "sub_screen.bob"
+    output_bob = tmp_path / "sub_screen.bob"
     formatter.format(device, "$(P)$(R)", output_bob)
 
     helper.assert_output_matches(expected_bob, output_bob)

--- a/tests/test_device_serialization.pvi.yaml
+++ b/tests/test_device_serialization.pvi.yaml
@@ -2,35 +2,35 @@
 label: label
 parent: parent
 children:
-- type: Group
-  name: Parameters
-  layout:
-    type: Grid
-  children:
-    - type: SignalRW
-      name: WidthUnits
-      pv: WIDTH:UNITS
-      widget:
-        type: ComboBox
-    - type: SignalRW
-      name: Width
-      pv: WIDTH
-      widget:
-        type: TextWrite
-      read_pv: WIDTH_RBV
-      read_widget:
-        type: TextRead
-- type: SignalRW
-  name: Table
-  pv: TABLE
-  widget:
-    type: TableWrite
-    widgets:
-      - type: CheckBox
-      - type: ComboBox
-      - type: TextWrite
-- type: SignalR
-  name: OutA
-  pv: OUTA
-  widget:
-    type: LED
+  - type: Group
+    name: Parameters
+    layout:
+      type: Grid
+    children:
+      - type: SignalRW
+        name: WidthUnits
+        pv: WIDTH:UNITS
+        widget:
+          type: ComboBox
+        read_pv: WIDTH:UNITS.RBV
+      - type: SignalRW
+        name: Width
+        pv: WIDTH
+        widget:
+          type: TextWrite
+        read_pv: WIDTH_RBV
+  - type: SignalRW
+    name: Table
+    pv: TABLE
+    widget:
+      type: TableWrite
+      widgets:
+        - type: CheckBox
+        - type: ComboBox
+        - type: TextWrite
+    read_pv: TABLE.RBV
+  - type: SignalR
+    name: OutA
+    pv: OUTA
+    widget:
+      type: LED

--- a/tests/test_device_serialization.pvi.yaml
+++ b/tests/test_device_serialization.pvi.yaml
@@ -12,13 +12,17 @@ children:
         pv: WIDTH:UNITS
         widget:
           type: ComboBox
-        read_pv: WIDTH:UNITS.RBV
+        read_pv: WIDTH:UNITS
+        read_widget:
+          type: TextRead
       - type: SignalRW
         name: Width
         pv: WIDTH
         widget:
           type: TextWrite
         read_pv: WIDTH_RBV
+        read_widget:
+          type: TextRead
   - type: SignalRW
     name: Table
     pv: TABLE
@@ -28,7 +32,9 @@ children:
         - type: CheckBox
         - type: ComboBox
         - type: TextWrite
-    read_pv: TABLE.RBV
+    read_pv: TABLE
+    read_widget:
+      type: TextRead
   - type: SignalR
     name: OutA
     pv: OUTA


### PR DESCRIPTION
Closes #41 

* If a `SignalRW` is used for a `ComboBox` the `read_pv` will not be displayed, only the `ComboBox` with no splitting.
* In a `SignalRW`, if a `read_pv` is not provided, the `read_pv` will be the same as the write `pv`.