### PR TITLE
Align the table header to the table when labels are used

### DIFF
--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -417,18 +417,30 @@ class ScreenFormatterFactory(Generic[T]):
                     c.children
                 ), "Header length does not match number of elements"
 
+                header_bounds = component_bounds.copy()
+                if add_label:
+                    # Scale the headers by the width with the label then
+                    # indent them
+                    original_width = len(c.layout.header) * (
+                        header_bounds.w + self.layout.spacing
+                    )
+                    label_width = self.layout.label_width + self.layout.spacing
+
+                    scaling_factor = (original_width - label_width) / original_width
+                    header_bounds.w = int(header_bounds.w * scaling_factor)
+
+                    header_bounds.indent(label_width)
+
                 # Create column headers
                 for column_header in c.layout.header:
                     yield self.widget_formatter_factory.header_formatter_cls(
-                        component_bounds.copy(), column_header
+                        header_bounds.copy(), column_header
                     )
-                    component_bounds.x += component_bounds.w + self.layout.spacing
+                    header_bounds.x += header_bounds.w + self.layout.spacing
 
-                # Reset x and shift down y
-                component_bounds.x = bounds.x
+                # Shift down y
                 component_bounds.y += self.layout.widget_height + self.layout.spacing
 
-            add_label = False  # Don't add a row label
             row_components = c.children  # Create a widget for each row of Group
             # Allow given component width for each column, plus spacing
             component_bounds = component_bounds.tile(

--- a/tests/format/output/static_table_BigTable.adl
+++ b/tests/format/output/static_table_BigTable.adl
@@ -7,7 +7,7 @@ display {
 	object {
 		x=0
 		y=0
-		width=1652
+		width=1650
 		height=150
 	}
 	clr=14
@@ -91,7 +91,7 @@ rectangle {
 	object {
 		x=0
 		y=0
-		width=1652
+		width=1650
 		height=26
 	}
 	"basic attribute" {
@@ -102,7 +102,7 @@ text {
 	object {
 		x=0
 		y=0
-		width=1652
+		width=1650
 		height=26
 	}
 	"basic attribute" {
@@ -113,9 +113,9 @@ text {
 }
 text {
 	object {
-		x=4
+		x=158
 		y=30
-		width=408
+		width=369
 		height=20
 	}
 	"basic attribute" {
@@ -126,9 +126,9 @@ text {
 }
 text {
 	object {
-		x=416
+		x=531
 		y=30
-		width=408
+		width=369
 		height=20
 	}
 	"basic attribute" {
@@ -139,9 +139,9 @@ text {
 }
 text {
 	object {
-		x=828
+		x=904
 		y=30
-		width=408
+		width=369
 		height=20
 	}
 	"basic attribute" {
@@ -152,9 +152,9 @@ text {
 }
 text {
 	object {
-		x=1240
+		x=1277
 		y=30
-		width=408
+		width=369
 		height=20
 	}
 	"basic attribute" {
@@ -163,9 +163,22 @@ text {
 	textix="String Column"
 	align="horiz. centered"
 }
+text {
+	object {
+		x=4
+		y=54
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Row 1"
+	align="horiz. right"
+}
 byte {
 	object {
-		x=198
+		x=332
 		y=54
 		width=20
 		height=20
@@ -179,9 +192,9 @@ byte {
 }
 "text update" {
 	object {
-		x=416
+		x=531
 		y=54
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -194,9 +207,9 @@ byte {
 }
 "text update" {
 	object {
-		x=828
+		x=904
 		y=54
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -209,9 +222,9 @@ byte {
 }
 "text update" {
 	object {
-		x=1240
+		x=1277
 		y=54
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -222,9 +235,22 @@ byte {
 	limits {
 	}
 }
+text {
+	object {
+		x=4
+		y=78
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Row 2"
+	align="horiz. right"
+}
 byte {
 	object {
-		x=198
+		x=332
 		y=78
 		width=20
 		height=20
@@ -238,9 +264,9 @@ byte {
 }
 "text update" {
 	object {
-		x=416
+		x=531
 		y=78
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -253,9 +279,9 @@ byte {
 }
 "text update" {
 	object {
-		x=828
+		x=904
 		y=78
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -268,9 +294,9 @@ byte {
 }
 "text update" {
 	object {
-		x=1240
+		x=1277
 		y=78
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -281,9 +307,22 @@ byte {
 	limits {
 	}
 }
+text {
+	object {
+		x=4
+		y=102
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Row 3"
+	align="horiz. right"
+}
 byte {
 	object {
-		x=198
+		x=332
 		y=102
 		width=20
 		height=20
@@ -297,9 +336,9 @@ byte {
 }
 "text update" {
 	object {
-		x=416
+		x=531
 		y=102
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -312,9 +351,9 @@ byte {
 }
 "text update" {
 	object {
-		x=828
+		x=904
 		y=102
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -327,9 +366,9 @@ byte {
 }
 "text update" {
 	object {
-		x=1240
+		x=1277
 		y=102
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -340,9 +379,22 @@ byte {
 	limits {
 	}
 }
+text {
+	object {
+		x=4
+		y=126
+		width=150
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Row 4"
+	align="horiz. right"
+}
 byte {
 	object {
-		x=198
+		x=332
 		y=126
 		width=20
 		height=20
@@ -356,9 +408,9 @@ byte {
 }
 "text update" {
 	object {
-		x=416
+		x=531
 		y=126
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -371,9 +423,9 @@ byte {
 }
 "text update" {
 	object {
-		x=828
+		x=904
 		y=126
-		width=408
+		width=369
 		height=20
 	}
 	monitor {
@@ -386,9 +438,9 @@ byte {
 }
 "text update" {
 	object {
-		x=1240
+		x=1277
 		y=126
-		width=408
+		width=369
 		height=20
 	}
 	monitor {

--- a/tests/format/output/static_table_BigTable.bob
+++ b/tests/format/output/static_table_BigTable.bob
@@ -28,9 +28,9 @@
   <widget type="label" version="2.0.0">
     <name>Heading</name>
     <text>Binary Column</text>
-    <x>22</x>
+    <x>146</x>
     <y>30</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font family="Liberation Sans" style="BOLD" size="16.0">
@@ -50,9 +50,9 @@
   <widget type="label" version="2.0.0">
     <name>Heading</name>
     <text>Long Column</text>
-    <x>274</x>
+    <x>367</x>
     <y>30</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font family="Liberation Sans" style="BOLD" size="16.0">
@@ -72,9 +72,9 @@
   <widget type="label" version="2.0.0">
     <name>Heading</name>
     <text>Float Column</text>
-    <x>526</x>
+    <x>588</x>
     <y>30</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font family="Liberation Sans" style="BOLD" size="16.0">
@@ -94,9 +94,9 @@
   <widget type="label" version="2.0.0">
     <name>Heading</name>
     <text>String Column</text>
-    <x>778</x>
+    <x>809</x>
     <y>30</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font family="Liberation Sans" style="BOLD" size="16.0">
@@ -113,10 +113,18 @@
     <transparent>false</transparent>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Row 1</text>
+    <x>22</x>
+    <y>54</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>
     <pv_name>$(P)$(R)BINARY_1</pv_name>
-    <x>136</x>
+    <x>244</x>
     <y>54</y>
     <width>20</width>
     <height>20</height>
@@ -124,9 +132,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)LONG_1</pv_name>
-    <x>274</x>
+    <x>367</x>
     <y>54</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -137,9 +145,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)FLOAT_1</pv_name>
-    <x>526</x>
+    <x>588</x>
     <y>54</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -150,9 +158,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)STRING_1</pv_name>
-    <x>778</x>
+    <x>809</x>
     <y>54</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -160,10 +168,18 @@
     </font>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Row 2</text>
+    <x>22</x>
+    <y>78</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>
     <pv_name>$(P)$(R)BINARY_2</pv_name>
-    <x>136</x>
+    <x>244</x>
     <y>78</y>
     <width>20</width>
     <height>20</height>
@@ -171,9 +187,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)LONG_2</pv_name>
-    <x>274</x>
+    <x>367</x>
     <y>78</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -184,9 +200,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)FLOAT_2</pv_name>
-    <x>526</x>
+    <x>588</x>
     <y>78</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -197,9 +213,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)STRING_2</pv_name>
-    <x>778</x>
+    <x>809</x>
     <y>78</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -207,10 +223,18 @@
     </font>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Row 3</text>
+    <x>22</x>
+    <y>102</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>
     <pv_name>$(P)$(R)BINARY_3</pv_name>
-    <x>136</x>
+    <x>244</x>
     <y>102</y>
     <width>20</width>
     <height>20</height>
@@ -218,9 +242,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)LONG_3</pv_name>
-    <x>274</x>
+    <x>367</x>
     <y>102</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -231,9 +255,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)FLOAT_3</pv_name>
-    <x>526</x>
+    <x>588</x>
     <y>102</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -244,9 +268,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)STRING_3</pv_name>
-    <x>778</x>
+    <x>809</x>
     <y>102</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -254,10 +278,18 @@
     </font>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Row 4</text>
+    <x>22</x>
+    <y>126</y>
+    <width>120</width>
+    <height>20</height>
+  </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>
     <pv_name>$(P)$(R)BINARY_4</pv_name>
-    <x>136</x>
+    <x>244</x>
     <y>126</y>
     <width>20</width>
     <height>20</height>
@@ -265,9 +297,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)LONG_4</pv_name>
-    <x>274</x>
+    <x>367</x>
     <y>126</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -278,9 +310,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)FLOAT_4</pv_name>
-    <x>526</x>
+    <x>588</x>
     <y>126</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
@@ -291,9 +323,9 @@
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
     <pv_name>$(P)$(R)STRING_4</pv_name>
-    <x>778</x>
+    <x>809</x>
     <y>126</y>
-    <width>248</width>
+    <width>217</width>
     <height>20</height>
     <font>
       <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">

--- a/tests/format/output/static_table_BigTable.edl
+++ b/tests/format/output/static_table_BigTable.edl
@@ -50,9 +50,9 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 10
+x 130
 y 30
-w 245
+w 215
 h 20
 font "arial-bold-r-12.0"
 fontAlign "center"
@@ -69,9 +69,9 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 260
+x 350
 y 30
-w 245
+w 215
 h 20
 font "arial-bold-r-12.0"
 fontAlign "center"
@@ -88,9 +88,9 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 510
+x 570
 y 30
-w 245
+w 215
 h 20
 font "arial-bold-r-12.0"
 fontAlign "center"
@@ -107,9 +107,9 @@ beginObjectProperties
 major 4
 minor 1
 release 1
-x 760
+x 790
 y 30
-w 245
+w 215
 h 20
 font "arial-bold-r-12.0"
 fontAlign "center"
@@ -120,13 +120,32 @@ value {
 }
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 55
+w 115
+h 20
+font "arial-bold-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Row 1"
+}
+endObjectProperties
+
 # (Byte)
 object ByteClass
 beginObjectProperties
 major 4
 minor 0
 release 0
-x 122
+x 227
 y 55
 w 20
 h 20
@@ -144,9 +163,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 260
+x 350
 y 55
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)LONG_1"
 fgColor index 16
@@ -163,9 +182,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 510
+x 570
 y 55
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)FLOAT_1"
 fgColor index 16
@@ -182,9 +201,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 760
+x 790
 y 55
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)STRING_1"
 fgColor index 16
@@ -195,13 +214,32 @@ font "arial-bold-r-12.0"
 fontAlign "center"
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 80
+w 115
+h 20
+font "arial-bold-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Row 2"
+}
+endObjectProperties
+
 # (Byte)
 object ByteClass
 beginObjectProperties
 major 4
 minor 0
 release 0
-x 122
+x 227
 y 80
 w 20
 h 20
@@ -219,9 +257,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 260
+x 350
 y 80
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)LONG_2"
 fgColor index 16
@@ -238,9 +276,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 510
+x 570
 y 80
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)FLOAT_2"
 fgColor index 16
@@ -257,9 +295,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 760
+x 790
 y 80
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)STRING_2"
 fgColor index 16
@@ -270,13 +308,32 @@ font "arial-bold-r-12.0"
 fontAlign "center"
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 105
+w 115
+h 20
+font "arial-bold-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Row 3"
+}
+endObjectProperties
+
 # (Byte)
 object ByteClass
 beginObjectProperties
 major 4
 minor 0
 release 0
-x 122
+x 227
 y 105
 w 20
 h 20
@@ -294,9 +351,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 260
+x 350
 y 105
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)LONG_3"
 fgColor index 16
@@ -313,9 +370,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 510
+x 570
 y 105
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)FLOAT_3"
 fgColor index 16
@@ -332,9 +389,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 760
+x 790
 y 105
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)STRING_3"
 fgColor index 16
@@ -345,13 +402,32 @@ font "arial-bold-r-12.0"
 fontAlign "center"
 endObjectProperties
 
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 130
+w 115
+h 20
+font "arial-bold-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Row 4"
+}
+endObjectProperties
+
 # (Byte)
 object ByteClass
 beginObjectProperties
 major 4
 minor 0
 release 0
-x 122
+x 227
 y 130
 w 20
 h 20
@@ -369,9 +445,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 260
+x 350
 y 130
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)LONG_4"
 fgColor index 16
@@ -388,9 +464,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 510
+x 570
 y 130
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)FLOAT_4"
 fgColor index 16
@@ -407,9 +483,9 @@ beginObjectProperties
 major 10
 minor 0
 release 0
-x 760
+x 790
 y 130
-w 245
+w 215
 h 20
 controlPv "$(P)$(R)STRING_4"
 fgColor index 16


### PR DESCRIPTION
Closes #49 
The table header is now also indented
if the table is given labels.
Regenerated table output in tests.