### PR TITLE
switch to trusted publisher for PyPI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -200,8 +200,12 @@ jobs:
     needs: [lint, dist, test]
     if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
-    env:
-      HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
+    permissions:
+      # this permission is mandatory for trusted publishing To PyPI
+      id-token: write
+      contents: write
+    # Specify the GitHub Environment to publish to
+    environment: release
 
     steps:
       - uses: actions/download-artifact@v3
@@ -224,7 +228,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI
-        if: ${{ env.HAS_PYPI_TOKEN }}
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
@GDYendel this is just bringing the PyPI publishing up to current approach as described [here](https://gitlab.diamond.ac.uk/sscc-docs/developer-guide/-/blob/pypi/docs/misc/how-tos/pypi.md)