### PR TITLE
Include YAML path in validation errors

### DIFF
--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -19,6 +19,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    ValidationError,
     field_validator,
     model_validator,
 )
@@ -463,7 +464,11 @@ class Device(TypedModel, YamlValidatorMixin):
 
         """
         serialized = cls.validate_yaml(yaml)
-        return cls(**serialized)
+        try:
+            return cls(**serialized)
+        except ValidationError:
+            print(f"\nFailed to validate `{yaml}` as Device:\n")
+            raise
 
     def deserialize_parents(self, yaml_paths: list[Path]):
         """Populate Device with Components from Device yaml of parent classes.

--- a/tests/bad.pvi.device.yaml
+++ b/tests/bad.pvi.device.yaml
@@ -1,0 +1,9 @@
+label: label
+parent: parent
+children:
+
+- type: SignalR
+  name: OutA
+  red_pv: OUTA
+  read_widget:
+    type: LED

--- a/tests/test_device_serialization.py
+++ b/tests/test_device_serialization.py
@@ -55,6 +55,7 @@ def device():
 
 
 DEVICE_YAML = Path(__file__).parent / "test.pvi.device.yaml"
+BAD_DEVICE_YAML = Path(__file__).parent / "bad.pvi.device.yaml"
 
 
 def test_serialize(device: Device):
@@ -70,6 +71,11 @@ def test_serialize(device: Device):
 def test_deserialize(device: Device):
     d = Device.deserialize(DEVICE_YAML)
     assert d == device
+
+
+def test_deserialize_raises():
+    with pytest.raises(ValidationError):
+        Device.deserialize(BAD_DEVICE_YAML)
 
 
 def test_validate_fails():


### PR DESCRIPTION
This prints the file path with pydantic `ValidationError`s raised when trying to create a `Device` instance from a dictionary loaded from a YAML file.

Fixes #99 