### PR TITLE
Add better validation for ButtonPanel actions

### DIFF
--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -96,13 +96,15 @@
       "description": "One-or-more buttons that poke a PV with a value\n\nArgs:\n    actions: Dict of button label to value the button sends",
       "properties": {
         "actions": {
-          "additionalProperties": {
-            "type": "string"
-          },
           "default": {
             "Go": "1"
           },
           "description": "PV poker buttons",
+          "patternProperties": {
+            "^([A-Z][a-z0-9]*)*$": {
+              "type": "string"
+            }
+          },
           "title": "Actions",
           "type": "object"
         },

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -75,6 +75,9 @@ def enforce_pascal_case(s: str) -> str:
     return s[0].upper() + s[1:]
 
 
+PascalStr = Annotated[str, Field(pattern="^([A-Z][a-z0-9]*)*$")]
+
+
 class TextFormat(Enum):
     """Format to use for display of Text{Read,Write} widgets on a UI"""
 
@@ -177,7 +180,9 @@ class ButtonPanel(WriteWidget):
 
     """
 
-    actions: Dict[str, str] = Field(default={"Go": "1"}, description="PV poker buttons")
+    actions: Dict[PascalStr, str] = Field(
+        default={"Go": "1"}, description="PV poker buttons"
+    )
 
 
 class TextWrite(WriteWidget):
@@ -280,10 +285,7 @@ WidgetUnion = ReadWidgetUnion | WriteWidgetUnion
 
 
 class Named(TypedModel):
-    name: str = Field(
-        description="PascalCase name to uniquely identify",
-        pattern=r"^([A-Z][a-z0-9]*)*$",
-    )
+    name: PascalStr = Field(description="PascalCase name to uniquely identify")
 
 
 class Component(Named):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from pvi._format.base import Formatter, IndexEntry
 from pvi._format.dls import DLSFormatter
@@ -93,6 +94,11 @@ def test_button(tmp_path, helper):
     formatter.format(device, output_bob)
 
     helper.assert_output_matches(expected_bob, output_bob)
+
+
+def test_button_raises(tmp_path, helper):
+    with pytest.raises(ValidationError, match="String should match pattern"):
+        ButtonPanel(actions={"start": "1", "Stop": "0"})
 
 
 def test_pva_table(tmp_path, helper):


### PR DESCRIPTION
This causes an error much earlier that more clearly links to the user's code:

```
...
  File "/workspaces/pvi/tests/test_api.py", line 99, in test_button_raises
    ButtonPanel(actions={"start": "1", "Stop": "0"})
  File "/venv/lib/python3.10/site-packages/pydantic/main.py", line 171, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ButtonPanel
actions.start.[key]
  String should match pattern '^([A-Z][a-z0-9]*)*$' [type=string_pattern_mismatch, input_value='start', input_type=str]
    For further information visit https://errors.pydantic.dev/2.6/v/string_pattern_mismatc
```

Fixes #97 