### PR TITLE
Use human-readable strings for TextFormat enum values

### DIFF
--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -993,14 +993,14 @@
     "TextFormat": {
       "description": "Format to use for display of Text{Read,Write} widgets on a UI",
       "enum": [
-        0,
-        1,
-        2,
-        3,
-        4
+        "decimal",
+        "hexadecimal",
+        "engineer",
+        "exponential",
+        "string"
       ],
       "title": "TextFormat",
-      "type": "integer"
+      "type": "string"
     },
     "TextRead": {
       "additionalProperties": false,

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -81,11 +81,11 @@ PascalStr = Annotated[str, Field(pattern="^([A-Z][a-z0-9]*)*$")]
 class TextFormat(Enum):
     """Format to use for display of Text{Read,Write} widgets on a UI"""
 
-    decimal = 0
-    hexadecimal = 1
-    engineer = 2
-    exponential = 3
-    string = 4
+    decimal = "decimal"
+    hexadecimal = "hexadecimal"
+    engineer = "engineer"
+    exponential = "exponential"
+    string = "string"
 
 
 class AccessModeMixin(BaseModel):

--- a/tests/convert/output/simDetector.pvi.device.yaml
+++ b/tests/convert/output/simDetector.pvi.device.yaml
@@ -26,7 +26,7 @@ children:
     read_pv: $(P)$(R)XMLErrorMsg_RBV
     read_widget:
       type: TextRead
-      format: 4
+      format: string
 
   - type: SignalR
     name: Dimensions


### PR DESCRIPTION
This is a breaking change.

Fixes #96 