### PR TITLE
Add option to convert templates to Device without header

### DIFF
--- a/src/pvi/_schema_utils.py
+++ b/src/pvi/_schema_utils.py
@@ -12,6 +12,7 @@ def rec_subclasses(cls: Cls) -> list[Cls]:
 
     subclasses: list[Cls] = []
     for sub_cls in cls.__subclasses__():
-        subclasses += [sub_cls] + rec_subclasses(sub_cls)
+        subclasses.append(sub_cls)
+        subclasses.extend(rec_subclasses(sub_cls))
 
     return subclasses

--- a/tests/convert/input/Mako125B.template
+++ b/tests/convert/input/Mako125B.template
@@ -1,0 +1,50 @@
+record(ai, "$(P)$(R)GC_FirmwareVerMajor_RBV") {
+  field(DTYP, "asynInt64")
+  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_FirmwareVerMajor")
+  field(SCAN, "I/O Intr")
+  field(DISA, "0")
+}
+
+record(ao, "$(P)$(R)GC_FirmwareVerBuild") {
+  field(DTYP, "asynInt64")
+  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_FirmwareVerBuild")
+  field(DISA, "0")
+}
+
+record(mbbi, "$(P)$(R)GC_SensorType_RBV") {
+  field(DTYP, "asynInt32")
+  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_E_SensorType")
+  field(ZRST, "Mono")
+  field(ZRVL, "0")
+  field(ONST, "Bayer")
+  field(ONVL, "1")
+  field(SCAN, "I/O Intr")
+  field(DISA, "0")
+}
+
+record(ai, "$(P)$(R)GC_SensorBits_RBV") {
+  field(DTYP, "asynInt64")
+  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_SensorBits")
+  field(SCAN, "I/O Intr")
+  field(DISA, "0")
+}
+
+record(ao, "$(P)$(R)GC_SensorBits") {
+  field(DTYP, "asynInt64")
+  field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_I_SensorBits")
+  field(DISA, "0")
+}
+
+record(stringin, "$(P)$(R)GC_DeviceVendorName_RBV") {
+  field(DTYP, "asynOctetRead")
+  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_S_DeviceVendorName")
+  field(SCAN, "I/O Intr")
+  field(DISA, "0")
+}
+
+record(stringin, "$(P)$(R)GC_DeviceModelName_RBV") {
+  field(DTYP, "asynOctetRead")
+  field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))GC_S_DeviceModelName")
+  field(SCAN, "I/O Intr")
+  field(DISA, "0")
+}

--- a/tests/convert/output/Mako125B.pvi.device.yaml
+++ b/tests/convert/output/Mako125B.pvi.device.yaml
@@ -1,0 +1,49 @@
+label: GenICam Mako125B
+parent: GenICamDriver
+children:
+
+- type: Group
+  name: Mako125B
+  layout:
+    type: Grid
+    labelled: true
+  children:
+
+  - type: SignalW
+    name: GCFirmwareVerBuild
+    write_pv: $(P)$(R)GC_FirmwareVerBuild
+    write_widget:
+      type: TextWrite
+
+  - type: SignalR
+    name: GCFirmwareVerMajor
+    read_pv: $(P)$(R)GC_FirmwareVerMajor_RBV
+    read_widget:
+      type: TextRead
+
+  - type: SignalR
+    name: GCSensorType
+    read_pv: $(P)$(R)GC_SensorType_RBV
+    read_widget:
+      type: TextRead
+
+  - type: SignalR
+    name: GCDeviceVendorName
+    read_pv: $(P)$(R)GC_DeviceVendorName_RBV
+    read_widget:
+      type: TextRead
+
+  - type: SignalR
+    name: GCDeviceModelName
+    read_pv: $(P)$(R)GC_DeviceModelName_RBV
+    read_widget:
+      type: TextRead
+
+  - type: SignalRW
+    name: GCSensorBits
+    write_pv: $(P)$(R)GC_SensorBits
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)GC_SensorBits_RBV
+    read_widget:
+      type: TextRead

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,7 +63,7 @@ def test_signal_default_widgets(tmp_path, helper):
     )
 
 
-def test_convert(tmp_path, helper):
+def test_convert_header(tmp_path, helper):
     expected_path = HERE / "convert" / "output"
     input_path = HERE / "convert" / "input"
     helper.assert_cli_output_matches(
@@ -71,9 +71,29 @@ def test_convert(tmp_path, helper):
         expected_path,
         "convert device",
         tmp_path,
+        "--header",
         input_path / "simDetector.h",
         "--template",
         input_path / "simDetector.template",
+    )
+
+
+def test_convert_device_name(tmp_path, helper):
+    expected_path = HERE / "convert" / "output"
+    input_path = HERE / "convert" / "input"
+    helper.assert_cli_output_matches(
+        app,
+        expected_path,
+        "convert device",
+        tmp_path,
+        "--name",
+        "Mako125B",
+        "--label",
+        "GenICam Mako125B",
+        "--parent",
+        "GenICamDriver",
+        "--template",
+        input_path / "Mako125B.template",
     )
 
 


### PR DESCRIPTION
This is a breaking change to the convert device CLI.

Change header from required positional arg to option --header.
Add --name and --parent args to specificy without header.
Add --label to override UI label of Device.

Fixes #120 