### PR TITLE
Fix regex used to convert PV to signal name

### DIFF
--- a/src/pvi/__main__.py
+++ b/src/pvi/__main__.py
@@ -46,9 +46,9 @@ def schema(
     ],
 ):
     """Write the JSON schema for the pvi interface"""
-    assert output.name.endswith(
-        ".schema.json"
-    ), f"Expected '{output.name}' to end with '.schema.json'"
+    assert output.name.endswith(".schema.json"), (
+        f"Expected '{output.name}' to end with '.schema.json'"
+    )
 
     if output.name == "pvi.device.schema.json":
         schema = Device.model_json_schema()

--- a/src/pvi/_convert/_parameters.py
+++ b/src/pvi/_convert/_parameters.py
@@ -58,7 +58,7 @@ class DisplayForm(Enum):
     ENGINEERING = "Engineering"
 
 
-MACRO_RE = re.compile(r"\$\(.*\)")
+MACRO_RE = re.compile(r"\$\([^\)]*\)")
 
 
 class Record(BaseModel):

--- a/src/pvi/_format/bob.py
+++ b/src/pvi/_format/bob.py
@@ -91,12 +91,9 @@ class BobTemplate(UITemplate[_Element]):
                 add_combo_box_items(t_copy, combo_box)
             case ("table", TableRead() | TableWrite() as table):
                 add_table_columns(t_copy, table)
-            case (
-                ("textentry", TextWrite(format=format))
-                | (
-                    "textupdate",
-                    TextRead(format=format),
-                )
+            case ("textentry", TextWrite(format=format)) | (
+                "textupdate",
+                TextRead(format=format),
             ) if format is not None:
                 add_format(t_copy, BOB_TEXT_FORMATS[TextFormat(format)])
             case ("byte_monitor", BitField() as bit_field):
@@ -157,9 +154,9 @@ class BobTemplate(UITemplate[_Element]):
         """
         padding = padding or Bounds()
 
-        assert (
-            len(group_object) == 1
-        ), f"Size of group_object is {len(group_object)}, should be 1"
+        assert len(group_object) == 1, (
+            f"Size of group_object is {len(group_object)}, should be 1"
+        )
         for c in children:
             group_object[0].append(c.format()[0])
         return group_object

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -292,9 +292,9 @@ class ScreenFormatterFactory(Generic[T]):
         column_bounds = Bounds(w=full_w, h=self.layout.widget_height)
         widget_factories: list[WidgetFormatter[T]] = []
 
-        assert isinstance(
-            group.layout, Grid | SubScreen
-        ), "Can only do Grid and SubScreen at the moment"
+        assert isinstance(group.layout, Grid | SubScreen), (
+            "Can only do Grid and SubScreen at the moment"
+        )
 
         for c in group.children:
             component: Group | Component
@@ -418,9 +418,9 @@ class ScreenFormatterFactory(Generic[T]):
             # This Group should be formatted as a table
             if c.layout.header is not None:
                 # Create table header
-                assert len(c.layout.header) == len(
-                    c.children
-                ), "Header length does not match number of elements"
+                assert len(c.layout.header) == len(c.children), (
+                    "Header length does not match number of elements"
+                )
 
                 header_bounds = component_bounds.clone()
                 if add_label:

--- a/src/pvi/_format/widget.py
+++ b/src/pvi/_format/widget.py
@@ -124,9 +124,9 @@ class WidgetFormatter(Generic[T]):
             properties: dict[str, str] = {}
             if property_map is not None:
                 for placeholder, widget_property in property_map.items():
-                    assert hasattr(
-                        self, widget_property
-                    ), f"{self} has no property {widget_property}"
+                    assert hasattr(self, widget_property), (
+                        f"{self} has no property {widget_property}"
+                    )
                     properties[placeholder] = getattr(self, widget_property)
 
             return [
@@ -240,9 +240,9 @@ class GroupFormatter(WidgetFormatter[T]):
                 properties: dict[str, str] = {}
                 if property_map is not None:
                     for placeholder, widget_property in property_map.items():
-                        assert hasattr(
-                            self, widget_property
-                        ), f"{self} has no property {widget_property}"
+                        assert hasattr(self, widget_property), (
+                            f"{self} has no property {widget_property}"
+                        )
                         properties[placeholder] = getattr(self, widget_property)
 
                 texts.append(


### PR DESCRIPTION
Previously if a PV started and ended with a macro then the regex would match the whole string and an empty string would be returned for the name.

With this change, converting NDAttrPlotAttr.template, NDAttrPlotData.template, NDGatherN.template works.

Fixes #144 