### PR TITLE
Clarify use of signal descriptions as label tooltips

### DIFF
--- a/src/pvi/_format/dls.py
+++ b/src/pvi/_format/dls.py
@@ -227,7 +227,7 @@ class DLSFormatter(Formatter):
                 label_formatter_cls=LabelWidgetFormatter[_Element].from_template(
                     template,
                     search="Label",
-                    property_map={"text": "text", "tooltip": "description"},
+                    property_map={"text": "text", "tooltip": "tooltip"},
                 ),
                 led_formatter_cls=PVWidgetFormatter[_Element].from_template(
                     template,

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -484,7 +484,9 @@ class ScreenFormatterFactory(Generic[T]):
                 self.layout.label_width, self.layout.spacing
             )
             yield self.widget_formatter_factory.label_formatter_cls(
-                bounds=left, text=c.get_label(), description=c.description or ""
+                bounds=left,
+                text=c.get_label(),
+                tooltip=c.description or "No description provided",
             )
         else:
             # Allow full width for widget

--- a/src/pvi/_format/widget.py
+++ b/src/pvi/_format/widget.py
@@ -148,7 +148,7 @@ class WidgetFormatter(Generic[T]):
 @dataclass
 class LabelWidgetFormatter(WidgetFormatter[T]):
     text: str
-    description: str = ""
+    tooltip: str = ""
 
 
 @dataclass

--- a/tests/format/input/all_widgets/ButtonPanel.pvi.device.yaml
+++ b/tests/format/input/all_widgets/ButtonPanel.pvi.device.yaml
@@ -3,6 +3,7 @@ label: ButtonPanel
 children:
   - type: SignalW
     name: ButtonPanel
+    description: One-or-more buttons that poke a PV with a value
     write_pv: $(P)$(R)ButtonPanel
     write_widget:
       type: ButtonPanel

--- a/tests/format/output/all_widgets/ArrayTrace.bob
+++ b/tests/format/output/all_widgets/ArrayTrace.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="xyplot" version="3.0.0">
     <name>ArrayTrace</name>

--- a/tests/format/output/all_widgets/BitField.bob
+++ b/tests/format/output/all_widgets/BitField.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="byte_monitor" version="2.0.0">
     <name>BitField</name>

--- a/tests/format/output/all_widgets/ButtonPanel.bob
+++ b/tests/format/output/all_widgets/ButtonPanel.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>One-or-more buttons that poke a PV with a value</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>WritePV</name>

--- a/tests/format/output/all_widgets/CheckBox.bob
+++ b/tests/format/output/all_widgets/CheckBox.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="checkbox" version="2.0.0">
     <name>CheckBox</name>

--- a/tests/format/output/all_widgets/ComboBox.bob
+++ b/tests/format/output/all_widgets/ComboBox.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="combo" version="2.0.0">
     <name>ComboBox</name>

--- a/tests/format/output/all_widgets/ImageRead.bob
+++ b/tests/format/output/all_widgets/ImageRead.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="image" version="2.0.0">
     <name>ImageRead</name>

--- a/tests/format/output/all_widgets/LED.bob
+++ b/tests/format/output/all_widgets/LED.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>

--- a/tests/format/output/all_widgets/ProgressBar.bob
+++ b/tests/format/output/all_widgets/ProgressBar.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="progressbar" version="2.0.0">
     <name>ProgressBar</name>

--- a/tests/format/output/all_widgets/TextRead.bob
+++ b/tests/format/output/all_widgets/TextRead.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>

--- a/tests/format/output/all_widgets/TextWrite.bob
+++ b/tests/format/output/all_widgets/TextWrite.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>

--- a/tests/format/output/all_widgets/ToggleButton.bob
+++ b/tests/format/output/all_widgets/ToggleButton.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="slide_button" version="2.0.0">
     <name>ToggleButton</name>
@@ -50,7 +50,7 @@
     <y>54</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="slide_button" version="2.0.0">
     <name>ToggleButton</name>

--- a/tests/format/output/all_widgets/all_widgets.bob
+++ b/tests/format/output/all_widgets/all_widgets.bob
@@ -39,7 +39,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="xyplot" version="3.0.0">
       <name>ArrayTrace</name>
@@ -82,7 +82,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="byte_monitor" version="2.0.0">
       <name>BitField</name>
@@ -107,7 +107,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>One-or-more buttons that poke a PV with a value</tooltip>
     </widget>
     <widget type="action_button" version="3.0.0">
       <name>WritePV</name>
@@ -158,7 +158,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="checkbox" version="2.0.0">
       <name>CheckBox</name>
@@ -185,7 +185,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
@@ -215,7 +215,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="image" version="2.0.0">
       <name>ImageRead</name>
@@ -240,7 +240,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="led" version="2.0.0">
       <name>LED</name>
@@ -265,7 +265,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="progressbar" version="2.0.0">
       <name>ProgressBar</name>
@@ -374,7 +374,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
@@ -404,7 +404,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
@@ -430,7 +430,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="slide_button" version="2.0.0">
       <name>ToggleButton</name>
@@ -448,7 +448,7 @@
       <y>24</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="slide_button" version="2.0.0">
       <name>ToggleButton</name>

--- a/tests/format/output/button.bob
+++ b/tests/format/output/button.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>
@@ -63,7 +63,7 @@
     <y>54</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>WritePV</name>
@@ -106,7 +106,7 @@
     <y>78</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>WritePV</name>

--- a/tests/format/output/combo_box.bob
+++ b/tests/format/output/combo_box.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="combo" version="2.0.0">
     <name>ComboBox</name>

--- a/tests/format/output/device_ref.bob
+++ b/tests/format/output/device_ref.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>

--- a/tests/format/output/index.bob
+++ b/tests/format/output/index.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>150</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
@@ -60,7 +60,7 @@
     <y>55</y>
     <width>150</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
@@ -88,7 +88,7 @@
     <y>80</y>
     <width>150</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>

--- a/tests/format/output/parent_child.bob
+++ b/tests/format/output/parent_child.bob
@@ -39,7 +39,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
@@ -61,7 +61,7 @@
       <y>24</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
@@ -91,7 +91,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>

--- a/tests/format/output/signal_default_widgets.bob
+++ b/tests/format/output/signal_default_widgets.bob
@@ -54,7 +54,7 @@
     <y>54</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>
@@ -72,7 +72,7 @@
     <y>78</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>
@@ -90,7 +90,7 @@
     <y>102</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>
@@ -121,7 +121,7 @@
     <y>126</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>WritePV</name>

--- a/tests/format/output/static_table.bob
+++ b/tests/format/output/static_table.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>

--- a/tests/format/output/static_table_BigTable.bob
+++ b/tests/format/output/static_table_BigTable.bob
@@ -120,7 +120,7 @@
     <y>54</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>
@@ -176,7 +176,7 @@
     <y>78</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>
@@ -232,7 +232,7 @@
     <y>102</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>
@@ -288,7 +288,7 @@
     <y>126</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="led" version="2.0.0">
     <name>LED</name>

--- a/tests/format/output/sub_screen.bob
+++ b/tests/format/output/sub_screen.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
@@ -77,7 +77,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
@@ -99,7 +99,7 @@
       <y>24</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="action_button" version="3.0.0">
       <name>OpenDisplay</name>

--- a/tests/format/output/sub_screen_Group1.bob
+++ b/tests/format/output/sub_screen_Group1.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
@@ -61,7 +61,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
@@ -83,7 +83,7 @@
       <y>24</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>

--- a/tests/format/output/sub_screen_Group4.bob
+++ b/tests/format/output/sub_screen_Group4.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>TextUpdate</name>
@@ -61,7 +61,7 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
@@ -83,7 +83,7 @@
       <y>24</y>
       <width>120</width>
       <height>20</height>
-      <tooltip>$(text)</tooltip>
+      <tooltip>No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>

--- a/tests/format/output/text_format.bob
+++ b/tests/format/output/text_format.bob
@@ -32,7 +32,7 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>
@@ -65,7 +65,7 @@
     <y>54</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>
@@ -98,7 +98,7 @@
     <y>78</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>
@@ -131,7 +131,7 @@
     <y>102</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>
@@ -164,7 +164,7 @@
     <y>126</y>
     <width>120</width>
     <height>20</height>
-    <tooltip>$(text)</tooltip>
+    <tooltip>No description provided</tooltip>
   </widget>
   <widget type="textentry" version="3.0.0">
     <name>TextEntry</name>


### PR DESCRIPTION
This PR just makes it more obvious that label tooltips can show descriptions if they are set and adds a description to one of the widget tests as an example. It also renames LabelWidgetFormatter description -> tooltip, because the tooltip could be used for other things.

```
  - type: SignalW
    name: ButtonPanel
    description: One-or-more buttons that poke a PV with a value
    write_pv: $(P)$(R)ButtonPanel
    write_widget:
      type: ButtonPanel
      actions:
        Stop: "0"
        Start: "1"
```

<img width="427" height="90" alt="image" src="https://github.com/user-attachments/assets/8690ff63-beee-4d8e-9395-b4f248de0517" />

<img width="335" height="87" alt="image" src="https://github.com/user-attachments/assets/4a601320-dc26-4db9-971c-2ecbcd150c8a" />

Fixes #86 