### PR TITLE
added Cell component to allow for multiple components in Table cells

### DIFF
--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -133,6 +133,92 @@
       "title": "ButtonPanel",
       "type": "object"
     },
+    "Cell": {
+      "additionalProperties": false,
+      "description": "A table cell containing vertically stacked child components",
+      "properties": {
+        "name": {
+          "description": "PascalCase name to uniquely identify",
+          "pattern": "^([A-Z][a-z0-9]*)*$",
+          "title": "Name",
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Label for component",
+          "title": "Label"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Description for label tooltip",
+          "title": "Description"
+        },
+        "children": {
+          "default": [],
+          "description": "Child Components",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/Group"
+              },
+              {
+                "$ref": "#/$defs/SignalR"
+              },
+              {
+                "$ref": "#/$defs/SignalW"
+              },
+              {
+                "$ref": "#/$defs/SignalRW"
+              },
+              {
+                "$ref": "#/$defs/SignalX"
+              },
+              {
+                "$ref": "#/$defs/IgnoredComponent"
+              },
+              {
+                "$ref": "#/$defs/SignalRef"
+              },
+              {
+                "$ref": "#/$defs/DeviceRef"
+              },
+              {
+                "$ref": "#/$defs/Cell"
+              }
+            ]
+          },
+          "title": "Children",
+          "type": "array"
+        },
+        "type": {
+          "const": "Cell",
+          "default": "Cell",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Cell",
+      "type": "object"
+    },
     "CheckBox": {
       "additionalProperties": false,
       "description": "Checkable control of a boolean PV.\n\nThis is compact replacement for a `ToggleButton` to be used in rows and tables.",
@@ -349,6 +435,9 @@
               },
               {
                 "$ref": "#/$defs/DeviceRef"
+              },
+              {
+                "$ref": "#/$defs/Cell"
               }
             ]
           },
@@ -1293,6 +1382,9 @@
               },
               {
                 "$ref": "#/$defs/DeviceRef"
+              },
+              {
+                "$ref": "#/$defs/Cell"
               }
             ]
           },

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -584,8 +584,12 @@ class ScreenFormatterFactory(Generic[T]):
                 child_bounds_list = rc_bounds.split_into_rows(
                     len(rc.children), self.layout.spacing
                 )
-                for child_bounds, child in zip(child_bounds_list, rc.children, strict=True):
-                    yield from self.generate_row_component_formatters([child], child_bounds)
+                for child_bounds, child in zip(
+                    child_bounds_list, rc.children, strict=True
+                ):
+                    yield from self.generate_row_component_formatters(
+                        [child], child_bounds
+                    )
             elif isinstance(rc, DeviceRef):
                 yield self.widget_formatter_factory.sub_screen_formatter_cls(
                     bounds=rc_bounds,

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -21,6 +21,7 @@ from pvi._format.widget import (
 from pvi.device import (
     ArrayTrace,
     ButtonPanel,
+    Cell,
     Component,
     ComponentUnion,
     DeviceRef,
@@ -479,10 +480,19 @@ class ScreenFormatterFactory(Generic[T]):
                 component_bounds.y += self.layout.widget_height + self.layout.spacing
 
             row_components = c.children  # Create a widget for each row of Group
+            max_stack = max(
+                len(child.children) if isinstance(child, Cell) else 1
+                for child in c.children
+            )
             # Allow given component width for each column, plus spacing
             component_bounds = component_bounds.tile(
                 horizontal=len(c.children), spacing=self.layout.spacing
             )
+            if max_stack > 1:
+                component_bounds.h = (
+                    max_stack * self.layout.widget_height
+                    + (max_stack - 1) * self.layout.spacing
+                )
         elif isinstance(c, SignalW) and isinstance(c.write_widget, ButtonPanel):
             # Convert SignalW into a SignalX with a fixed value for each action
             row_components = [
@@ -570,6 +580,12 @@ class ScreenFormatterFactory(Generic[T]):
                     file_name=f"{self.base_file_name}_{rc.name.replace(' ', '_')}",
                     components=rc,
                 )
+            elif isinstance(rc, Cell):
+                child_bounds_list = rc_bounds.split_into_rows(
+                    len(rc.children), self.layout.spacing
+                )
+                for child_bounds, child in zip(child_bounds_list, rc.children, strict=True):
+                    yield from self.generate_row_component_formatters([child], child_bounds)
             elif isinstance(rc, DeviceRef):
                 yield self.widget_formatter_factory.sub_screen_formatter_cls(
                     bounds=rc_bounds,

--- a/src/pvi/_format/utils.py
+++ b/src/pvi/_format/utils.py
@@ -43,6 +43,14 @@ class Bounds(BaseModel):
         """Split horizontally into count equal widths, separated by spacing"""
         return self.split_by_ratio((1 / count,) * count, spacing)
 
+    def split_into_rows(self, count: int, spacing: int) -> tuple[Bounds, ...]:
+        """Split vertically into count equal heights, separated by spacing"""
+        widget_h = (self.h - (count - 1) * spacing) // count
+        return tuple(
+            Bounds(x=self.x, y=self.y + i * (widget_h + spacing), w=self.w, h=widget_h)
+            for i in range(count)
+        )
+
     def square(self) -> Bounds:
         """Return the largest square that will fit in self"""
         size = min(self.w, self.h)

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -228,7 +228,6 @@ if not TYPE_CHECKING:
     _RowWriteUnion = as_tagged_union(_RowWriteUnion)
     _RowReadUnion = as_tagged_union(_RowReadUnion)
 
-
 class ArrayWrite(WriteWidget):
     """Control of an array PV"""
 
@@ -241,7 +240,7 @@ class TableRead(ReadWidget):
     """A read-only tabular view of an NTTable."""
 
     widgets: Annotated[
-        Sequence[_RowReadUnion],
+        Sequence[Cell],
         Field(
             description="For each column, what widget should be repeated for every row",
         ),
@@ -252,7 +251,7 @@ class TableWrite(WriteWidget):
     """A writeable tabular view of an NTTable."""
 
     widgets: Annotated[
-        Sequence[_RowWriteUnion],
+        Sequence[Cell],
         Field(
             description="For each column, what widget should be repeated for every row",
         ),
@@ -458,6 +457,12 @@ class Group(Component):
     children: Annotated[ResolvedTree, Field(description="Child Components")] = []
 
 
+class Cell(Component):
+    """A table cell containing vertically stacked child components"""
+
+    children: Annotated[ResolvedTree, Field(description="Child Components")] = []
+
+
 ComponentUnion = (
     Group
     | SignalR
@@ -467,6 +472,7 @@ ComponentUnion = (
     | IgnoredComponent
     | SignalRef
     | DeviceRef
+    | Cell
 )
 
 

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -228,6 +228,7 @@ if not TYPE_CHECKING:
     _RowWriteUnion = as_tagged_union(_RowWriteUnion)
     _RowReadUnion = as_tagged_union(_RowReadUnion)
 
+
 class ArrayWrite(WriteWidget):
     """Control of an array PV"""
 
@@ -240,7 +241,7 @@ class TableRead(ReadWidget):
     """A read-only tabular view of an NTTable."""
 
     widgets: Annotated[
-        Sequence[Cell],
+        Sequence[_RowReadUnion],
         Field(
             description="For each column, what widget should be repeated for every row",
         ),
@@ -251,7 +252,7 @@ class TableWrite(WriteWidget):
     """A writeable tabular view of an NTTable."""
 
     widgets: Annotated[
-        Sequence[Cell],
+        Sequence[_RowWriteUnion],
         Field(
             description="For each column, what widget should be repeated for every row",
         ),


### PR DESCRIPTION
Adding Cells to allow for table designs like the EDM screen found here:
https://areadetector.github.io/areaDetector/ADCore/NDPluginROI.html

<img width="1044" height="290" alt="Screenshot from 2026-03-27 14-01-08" src="https://github.com/user-attachments/assets/de62f29e-95a4-43b2-891e-8c9412cc540f" />

Previously:

<img width="1720" height="145" alt="Screenshot from 2026-03-27 14-12-29" src="https://github.com/user-attachments/assets/28cd8d21-8878-49da-9510-1652b1ab90bc" />

Now:

<img width="1051" height="258" alt="Screenshot from 2026-03-27 14-11-39" src="https://github.com/user-attachments/assets/61c81df4-4e14-41f1-9414-b30a2716c198" />

Usage in pvi.device.yaml:

<img width="371" height="382" alt="Screenshot from 2026-03-27 13-56-31" src="https://github.com/user-attachments/assets/aabba873-9370-41f8-81f1-ba7271e32418" />

- Either named cells or single widgets can be used within tables.
- Always stack vertically