### PR TITLE
Tables

### DIFF
--- a/pvi.template
+++ b/pvi.template
@@ -1,0 +1,48 @@
+
+### PV Interface for Simple Device ###
+
+record("*", "Status_RBV") {
+    info(Q:group, {
+        "PREFIXPVI": {
+            "pvi.Status.r": {
+                "+channel": "NAME",
+                "+type": "plain",
+            }
+        }
+    })
+}
+
+record("*", "Config") {
+    info(Q:group, {
+        "PREFIXPVI": {
+            "pvi.Config.w": {
+                "+channel": "NAME",
+                "+type": "plain",
+            }
+        }
+    })
+}
+
+record("*", "Config_RBV") {
+    info(Q:group, {
+        "PREFIXPVI": {
+            "pvi.Config.r": {
+                "+channel": "NAME",
+                "+type": "plain",
+            }
+        }
+    })
+}
+
+record("*", "Go") {
+    info(Q:group, {
+        "PREFIXPVI": {
+            "pvi.Command.x": {
+                "+channel": "NAME",
+                "+type": "plain",
+            }
+        }
+    })
+}
+
+### End of PV Interface for Simple Device ###

--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -257,6 +257,12 @@
           "title": "Labelled",
           "type": "boolean"
         },
+        "stacked": {
+          "default": false,
+          "description": "If True, RW widgets in each row are stacked vertically",
+          "title": "Stacked",
+          "type": "boolean"
+        },
         "type": {
           "const": "Grid",
           "default": "Grid",
@@ -1026,6 +1032,12 @@
           "default": true,
           "description": "Display labels for components",
           "title": "Labelled",
+          "type": "boolean"
+        },
+        "stacked": {
+          "default": false,
+          "description": "If True, RW widgets in each row are stacked vertically",
+          "title": "Stacked",
           "type": "boolean"
         },
         "type": {

--- a/simple.bob
+++ b/simple.bob
@@ -1,0 +1,108 @@
+<display version="2.0.0">
+  <name>Simple Device</name>
+  <x>0</x>
+  <y use_class="true">0</y>
+  <width>438</width>
+  <height>105</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Simple Device</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>438</width>
+    <height>25</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Status</text>
+    <x>23</x>
+    <y>30</y>
+    <width>200</width>
+    <height>20</height>
+    <tooltip>Status - No description provided</tooltip>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>TextUpdate</name>
+    <pv_name>Status_RBV</pv_name>
+    <x>228</x>
+    <y>30</y>
+    <width>205</width>
+    <height>20</height>
+    <font>
+      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+    </font>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Config</text>
+    <x>23</x>
+    <y>55</y>
+    <width>200</width>
+    <height>20</height>
+    <tooltip>Config - No description provided</tooltip>
+  </widget>
+  <widget type="textentry" version="3.0.0">
+    <name>TextEntry</name>
+    <pv_name>Config</pv_name>
+    <x>228</x>
+    <y>55</y>
+    <width>100</width>
+    <height>20</height>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>TextUpdate</name>
+    <pv_name>Config_RBV</pv_name>
+    <x>333</x>
+    <y>55</y>
+    <width>100</width>
+    <height>20</height>
+    <font>
+      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+    </font>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Command</text>
+    <x>23</x>
+    <y>80</y>
+    <width>200</width>
+    <height>20</height>
+    <tooltip>Command - No description provided</tooltip>
+  </widget>
+  <widget type="action_button" version="3.0.0">
+    <name>WritePV</name>
+    <pv_name>Go</pv_name>
+    <actions>
+      <action type="write_pv">
+        <pv_name>$(pv_name)</pv_name>
+        <value>1</value>
+        <description>$(name)</description>
+      </action>
+    </actions>
+    <text>Go</text>
+    <x>228</x>
+    <y>80</y>
+    <width>205</width>
+    <height>20</height>
+    <tooltip>Go = 1
+$(pv_value)</tooltip>
+  </widget>
+</display>

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -91,6 +91,7 @@ class ScreenFormatterFactory(Generic[T]):
         columns: list[Bounds] = [Bounds(**widget_dims)]
 
         content_stacked = False
+        in_subscreen = False
         match components:
             case [Group(layout=SubScreen(stacked=stacked)) as component]:
                 # Expand single group sub screen as only component on screen
@@ -98,6 +99,7 @@ class ScreenFormatterFactory(Generic[T]):
                 # being replaced by a sub screen button in the original location
                 components = component.children
                 content_stacked = stacked
+                in_subscreen = True
             case _:
                 pass
 
@@ -127,6 +129,7 @@ class ScreenFormatterFactory(Generic[T]):
                         screen_bounds=screen_bounds,
                         column_bounds=last_column_bounds,
                         next_column_bounds=next_column_bounds,
+                        squeeze=not in_subscreen,
                     )
                 )
             else:
@@ -225,6 +228,7 @@ class ScreenFormatterFactory(Generic[T]):
         screen_bounds: Bounds,
         column_bounds: Bounds,
         next_column_bounds: Bounds,
+        squeeze: bool = True,
     ) -> list[WidgetFormatter[T]]:
         """Create widget formatters for a Group
 
@@ -246,18 +250,6 @@ class ScreenFormatterFactory(Generic[T]):
             added widget
 
         """
-        if is_table(c):
-            # Make a sub screen button at the root to display this Group instead of
-            # embedding the components within a Group widget
-            c = Group(
-                name=c.name,
-                layout=SubScreen(
-                    labelled=False,
-                    stacked=isinstance(c.layout, Grid) and c.layout.stacked,
-                ),
-                children=c.children,
-            )
-
         if isinstance(c.layout, SubScreen):
             return self.create_component_widget_formatters(
                 Group(name=c.name, layout=c.layout, children=c.children),
@@ -271,7 +263,9 @@ class ScreenFormatterFactory(Generic[T]):
             split_out_plots(c)
 
         group_formatter = self.create_group_formatter(
-            c, bounds=Bounds(x=column_bounds.x, y=column_bounds.y, h=screen_bounds.h)
+            c,
+            bounds=Bounds(x=column_bounds.x, y=column_bounds.y, h=screen_bounds.h),
+            squeeze=squeeze,
         )
 
         if group_formatter.bounds.h + group_formatter.bounds.y <= screen_bounds.h:
@@ -291,6 +285,7 @@ class ScreenFormatterFactory(Generic[T]):
                 bounds=Bounds(
                     x=next_column_bounds.x, y=next_column_bounds.y, h=screen_bounds.h
                 ),
+                squeeze=squeeze,
             )
             group_formatter.bounds.w += self.layout.group_width_offset
 
@@ -302,7 +297,9 @@ class ScreenFormatterFactory(Generic[T]):
 
         return [group_formatter]
 
-    def create_group_formatter(self, group: Group, bounds: Bounds) -> GroupFormatter[T]:
+    def create_group_formatter(
+        self, group: Group, bounds: Bounds, squeeze: bool = True
+    ) -> GroupFormatter[T]:
         """Convert components within groups into widgets and lay them out within a
         group object.
 
@@ -336,15 +333,9 @@ class ScreenFormatterFactory(Generic[T]):
                     component = c
                 case Group(layout=Grid(labelled=labelled)):
                     add_label = labelled
-                    if is_table(c):
-                        # Display table on a sub screen
-                        component = Group(
-                            name=c.name, layout=SubScreen(), children=c.children
-                        )
-                    else:
-                        raise NotImplementedError(
-                            "Cannot nest a Group(Grid()) in another Group on one screen"
-                        )
+                    raise NotImplementedError(
+                        "Cannot nest a Group(Grid()) in another Group on one screen"
+                    )
                 case _:
                     # Make single line with a component or Row of components
                     component = c
@@ -362,6 +353,7 @@ class ScreenFormatterFactory(Generic[T]):
                     next_column_bounds=next_column_bounds,
                     add_label=add_label,
                     stacked=isinstance(group.layout, Grid) and group.layout.stacked,
+                    squeeze=squeeze,
                 )
             )
             if next_column_bounds.y != 0:
@@ -383,6 +375,7 @@ class ScreenFormatterFactory(Generic[T]):
         indent: bool = False,
         add_label: bool = True,
         stacked: bool = False,
+        squeeze: bool = False,
     ) -> list[WidgetFormatter[T]]:
         """Generate widgets from component data and position them in a grid format
 
@@ -421,7 +414,9 @@ class ScreenFormatterFactory(Generic[T]):
             tmp_next_column_bounds.h = tmp_column_bounds.h
 
         widgets = list(
-            self.generate_component_formatters(c, tmp_column_bounds, add_label, stacked)
+            self.generate_component_formatters(
+                c, tmp_column_bounds, add_label, stacked, squeeze
+            )
         )
         if max_y(widgets) <= parent_bounds.h:
             # Current column still fits on screen
@@ -430,7 +425,7 @@ class ScreenFormatterFactory(Generic[T]):
             # Widget makes current column too tall. Repeat in next column.
             widgets = list(
                 self.generate_component_formatters(
-                    c, tmp_next_column_bounds, add_label, stacked
+                    c, tmp_next_column_bounds, add_label, stacked, squeeze
                 )
             )
             next_column_bounds.y = next_y(widgets, self.layout.spacing)
@@ -443,6 +438,7 @@ class ScreenFormatterFactory(Generic[T]):
         bounds: Bounds,
         add_label: bool = True,
         stacked: bool = False,
+        squeeze: bool = False,
     ) -> Iterator[WidgetFormatter[T]]:
         """Convert a component into its WidgetFormatter equivalents
 
@@ -462,8 +458,27 @@ class ScreenFormatterFactory(Generic[T]):
         # Take a copy to modify in this scope
         component_bounds = bounds.clone()
 
+        effective_label_w = self.layout.label_width
+
         if isinstance(c, Group) and isinstance(c.layout, Row):
             # This Group should be formatted as a table
+            widget_w = (
+                component_bounds.w - self.layout.label_width - self.layout.spacing
+            )
+            n = len(c.children)
+            if squeeze:
+                available_content = component_bounds.w - self.layout.spacing * n
+                scale = available_content / (self.layout.label_width + widget_w * n)
+                effective_label_w = round(self.layout.label_width * scale)
+                widget_w = (available_content - effective_label_w) // n
+            else:
+                component_bounds.w = (
+                    self.layout.label_width
+                    + self.layout.spacing
+                    + widget_w * n
+                    + self.layout.spacing * (n - 1)
+                )
+
             if c.layout.header is not None:
                 # Create table header
                 assert len(c.layout.header) == len(c.children), (
@@ -472,17 +487,8 @@ class ScreenFormatterFactory(Generic[T]):
 
                 header_bounds = component_bounds.clone()
                 if add_label:
-                    # Scale the headers by the width with the label then
-                    # indent them
-                    original_width = len(c.layout.header) * (
-                        header_bounds.w + self.layout.spacing
-                    )
-                    label_width = self.layout.label_width + self.layout.spacing
-
-                    scaling_factor = (original_width - label_width) / original_width
-                    header_bounds.w = int(header_bounds.w * scaling_factor)
-
-                    header_bounds.indent(label_width)
+                    header_bounds.w = widget_w
+                    header_bounds.indent(effective_label_w + self.layout.spacing)
 
                 # Create column headers
                 for column_header in c.layout.header:
@@ -500,10 +506,6 @@ class ScreenFormatterFactory(Generic[T]):
                 for child in c.children
             ):
                 component_bounds.h = 2 * self.layout.widget_height + self.layout.spacing
-            # Allow given component width for each column, plus spacing
-            component_bounds = component_bounds.tile(
-                horizontal=len(c.children), spacing=self.layout.spacing
-            )
         elif isinstance(c, SignalW) and isinstance(c.write_widget, ButtonPanel):
             # Convert SignalW into a SignalX with a fixed value for each action
             row_components = [
@@ -534,7 +536,7 @@ class ScreenFormatterFactory(Generic[T]):
         if add_label:
             # Insert label and reduce width for widget
             left, row_bounds = component_bounds.split_left(
-                self.layout.label_width, self.layout.spacing
+                effective_label_w, self.layout.spacing
             )
             yield self.widget_formatter_factory.label_formatter_cls(
                 bounds=left,

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -90,12 +90,14 @@ class ScreenFormatterFactory(Generic[T]):
         screen_widgets: list[WidgetFormatter[T]] = []
         columns: list[Bounds] = [Bounds(**widget_dims)]
 
+        content_stacked = False
         match components:
-            case [Group(layout=SubScreen()) as component]:
+            case [Group(layout=SubScreen(stacked=stacked)) as component]:
                 # Expand single group sub screen as only component on screen
                 # This is where the actual content of sub screens are created after
                 # being replaced by a sub screen button in the original location
                 components = component.children
+                content_stacked = stacked
             case _:
                 pass
 
@@ -138,6 +140,7 @@ class ScreenFormatterFactory(Generic[T]):
                         next_column_bounds=next_column_bounds,
                         # Indent top-level widgets to align with Group widgets
                         indent=True,
+                        stacked=content_stacked,
                     )
                 )
 
@@ -247,7 +250,12 @@ class ScreenFormatterFactory(Generic[T]):
             # Make a sub screen button at the root to display this Group instead of
             # embedding the components within a Group widget
             c = Group(
-                name=c.name, layout=SubScreen(labelled=False), children=c.children
+                name=c.name,
+                layout=SubScreen(
+                    labelled=False,
+                    stacked=isinstance(c.layout, Grid) and c.layout.stacked,
+                ),
+                children=c.children,
             )
 
         if isinstance(c.layout, SubScreen):
@@ -353,6 +361,7 @@ class ScreenFormatterFactory(Generic[T]):
                     column_bounds=column_bounds,
                     next_column_bounds=next_column_bounds,
                     add_label=add_label,
+                    stacked=isinstance(group.layout, Grid) and group.layout.stacked,
                 )
             )
             if next_column_bounds.y != 0:
@@ -373,6 +382,7 @@ class ScreenFormatterFactory(Generic[T]):
         next_column_bounds: Bounds,
         indent: bool = False,
         add_label: bool = True,
+        stacked: bool = False,
     ) -> list[WidgetFormatter[T]]:
         """Generate widgets from component data and position them in a grid format
 
@@ -406,9 +416,12 @@ class ScreenFormatterFactory(Generic[T]):
         if isinstance(c, SignalR) and isinstance(c.read_widget, ImageRead | ArrayTrace):
             tmp_column_bounds.w = c.read_widget.width
             tmp_column_bounds.h = c.read_widget.height
+        elif stacked and isinstance(c, SignalRW) and c.read_widget is not None:
+            tmp_column_bounds.h = 2 * self.layout.widget_height + self.layout.spacing
+            tmp_next_column_bounds.h = tmp_column_bounds.h
 
         widgets = list(
-            self.generate_component_formatters(c, tmp_column_bounds, add_label)
+            self.generate_component_formatters(c, tmp_column_bounds, add_label, stacked)
         )
         if max_y(widgets) <= parent_bounds.h:
             # Current column still fits on screen
@@ -416,7 +429,9 @@ class ScreenFormatterFactory(Generic[T]):
         else:
             # Widget makes current column too tall. Repeat in next column.
             widgets = list(
-                self.generate_component_formatters(c, tmp_next_column_bounds, add_label)
+                self.generate_component_formatters(
+                    c, tmp_next_column_bounds, add_label, stacked
+                )
             )
             next_column_bounds.y = next_y(widgets, self.layout.spacing)
 
@@ -427,6 +442,7 @@ class ScreenFormatterFactory(Generic[T]):
         c: ComponentUnion,
         bounds: Bounds,
         add_label: bool = True,
+        stacked: bool = False,
     ) -> Iterator[WidgetFormatter[T]]:
         """Convert a component into its WidgetFormatter equivalents
 
@@ -479,6 +495,11 @@ class ScreenFormatterFactory(Generic[T]):
                 component_bounds.y += self.layout.widget_height + self.layout.spacing
 
             row_components = c.children  # Create a widget for each row of Group
+            if stacked and any(
+                isinstance(child, SignalRW) and child.read_widget is not None
+                for child in c.children
+            ):
+                component_bounds.h = 2 * self.layout.widget_height + self.layout.spacing
             # Allow given component width for each column, plus spacing
             component_bounds = component_bounds.tile(
                 horizontal=len(c.children), spacing=self.layout.spacing
@@ -531,12 +552,15 @@ class ScreenFormatterFactory(Generic[T]):
             )
             return
 
-        yield from self.generate_row_component_formatters(row_components, row_bounds)
+        yield from self.generate_row_component_formatters(
+            row_components, row_bounds, stacked
+        )
 
     def generate_row_component_formatters(
         self,
         row_components: Sequence[Group | Component],
         row_bounds: Bounds,
+        stacked: bool = False,
     ) -> Iterator[WidgetFormatter[T]]:
         row_component_bounds = row_bounds.clone().split_into(
             len(row_components), self.layout.spacing
@@ -553,7 +577,11 @@ class ScreenFormatterFactory(Generic[T]):
                     value=rc.value,
                 )
             elif isinstance(rc, SignalRW):
-                if rc.read_widget:
+                if stacked and rc.read_widget:
+                    top, bottom = rc_bounds.split_into_rows(2, self.layout.spacing)
+                    yield from self.generate_write_widget(rc, top)
+                    yield from self.generate_read_widget(rc, bottom)
+                elif rc.read_widget:
                     left, right = rc_bounds.split_into(2, self.layout.spacing)
                     yield from self.generate_write_widget(rc, left)
                     yield from self.generate_read_widget(rc, right)

--- a/src/pvi/_format/utils.py
+++ b/src/pvi/_format/utils.py
@@ -43,6 +43,14 @@ class Bounds(BaseModel):
         """Split horizontally into count equal widths, separated by spacing"""
         return self.split_by_ratio((1 / count,) * count, spacing)
 
+    def split_into_rows(self, count: int, spacing: int) -> tuple[Bounds, ...]:
+        """Split vertically into count equal heights, separated by spacing"""
+        widget_h = (self.h - (count - 1) * spacing) // count
+        return tuple(
+            Bounds(x=self.x, y=self.y + i * (widget_h + spacing), w=self.w, h=widget_h)
+            for i in range(count)
+        )
+
     def square(self) -> Bounds:
         """Return the largest square that will fit in self"""
         size = min(self.w, self.h)

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -282,11 +282,21 @@ class Grid(Layout):
         bool, Field(description="If True use names of children as labels")
     ] = True
 
+    stacked: Annotated[
+        bool,
+        Field(description="If True, RW widgets in each row are stacked vertically"),
+    ] = False
+
 
 class SubScreen(Layout):
     """Children are displayed on another screen opened with a button."""
 
     labelled: Annotated[bool, Field(description="Display labels for components")] = True
+
+    stacked: Annotated[
+        bool,
+        Field(description="If True, RW widgets in each row are stacked vertically"),
+    ] = False
 
 
 LayoutUnion = Plot | Row | Grid | SubScreen

--- a/tests/convert/output/Mako125B.pvi.device.yaml
+++ b/tests/convert/output/Mako125B.pvi.device.yaml
@@ -5,6 +5,7 @@ children:
     layout:
       type: Grid
       labelled: true
+      stacked: false
     children:
       - type: SignalW
         name: GCFirmwareVerBuild

--- a/tests/convert/output/simDetector.pvi.device.yaml
+++ b/tests/convert/output/simDetector.pvi.device.yaml
@@ -5,6 +5,7 @@ children:
     layout:
       type: Grid
       labelled: true
+      stacked: false
     children:
       - type: SignalW
         name: ResetPower

--- a/tests/format/output/static_table.adl
+++ b/tests/format/output/static_table.adl
@@ -7,8 +7,8 @@ display {
 	object {
 		x=0
 		y=0
-		width=416
-		height=78
+		width=422
+		height=207
 	}
 	clr=14
 	bclr=4
@@ -91,7 +91,7 @@ rectangle {
 	object {
 		x=0
 		y=0
-		width=416
+		width=422
 		height=26
 	}
 	"basic attribute" {
@@ -102,7 +102,7 @@ text {
 	object {
 		x=0
 		y=0
-		width=416
+		width=422
 		height=26
 	}
 	"basic attribute" {
@@ -138,16 +138,379 @@ byte {
 	}
 	sbit=0
 }
-"related display" {
+rectangle {
 	object {
 		x=4
 		y=54
-		width=408
+		width=414
+		height=149
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+}
+rectangle {
+	object {
+		x=8
+		y=58
+		width=406
+		height=21
+	}
+	"basic attribute" {
+		clr=2
+	}
+}
+text {
+	object {
+		x=8
+		y=58
+		width=406
+		height=21
+	}
+	"basic attribute" {
+		clr=54
+	}
+	textix="Big Table"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=62
+		y=83
+		width=85
 		height=20
 	}
-	display[0] {
-		name="static_table_BigTable.adl"
+	"basic attribute" {
+		clr=14
 	}
-	clr=14
-	bclr=4
+	textix="Binary Column"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=151
+		y=83
+		width=85
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Long Column"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=240
+		y=83
+		width=85
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Float Column"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=329
+		y=83
+		width=85
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="String Column"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=8
+		y=107
+		width=50
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Row 1"
+	align="horiz. right"
+}
+byte {
+	object {
+		x=94
+		y=107
+		width=20
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)BINARY_1"
+		clr=60
+		bclr=64
+	}
+	sbit=0
+}
+"text update" {
+	object {
+		x=151
+		y=107
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)LONG_1"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=240
+		y=107
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)FLOAT_1"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=329
+		y=107
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)STRING_1"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=8
+		y=131
+		width=50
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Row 2"
+	align="horiz. right"
+}
+byte {
+	object {
+		x=94
+		y=131
+		width=20
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)BINARY_2"
+		clr=60
+		bclr=64
+	}
+	sbit=0
+}
+"text update" {
+	object {
+		x=151
+		y=131
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)LONG_2"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=240
+		y=131
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)FLOAT_2"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=329
+		y=131
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)STRING_2"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=8
+		y=155
+		width=50
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Row 3"
+	align="horiz. right"
+}
+byte {
+	object {
+		x=94
+		y=155
+		width=20
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)BINARY_3"
+		clr=60
+		bclr=64
+	}
+	sbit=0
+}
+"text update" {
+	object {
+		x=151
+		y=155
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)LONG_3"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=240
+		y=155
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)FLOAT_3"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=329
+		y=155
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)STRING_3"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=8
+		y=179
+		width=50
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Row 4"
+	align="horiz. right"
+}
+byte {
+	object {
+		x=94
+		y=179
+		width=20
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)BINARY_4"
+		clr=60
+		bclr=64
+	}
+	sbit=0
+}
+"text update" {
+	object {
+		x=151
+		y=179
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)LONG_4"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=240
+		y=179
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)FLOAT_4"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=329
+		y=179
+		width=85
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)STRING_4"
+		clr=54
+		bclr=4
+	}
+	limits {
+	}
 }

--- a/tests/format/output/static_table.bob
+++ b/tests/format/output/static_table.bob
@@ -2,8 +2,8 @@
   <name>StaticTable - $(P)$(R)</name>
   <x>0</x>
   <y use_class="true">0</y>
-  <width>274</width>
-  <height>78</height>
+  <width>287</width>
+  <height>208</height>
   <grid_step_x>4</grid_step_x>
   <grid_step_y>4</grid_step_y>
   <widget type="label" version="2.0.0">
@@ -12,7 +12,7 @@
     <text>StaticTable - $(P)$(R)</text>
     <x use_class="true">0</x>
     <y use_class="true">0</y>
-    <width>274</width>
+    <width>287</width>
     <height>26</height>
     <font use_class="true">
       <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
@@ -42,20 +42,324 @@
     <width>20</width>
     <height>20</height>
   </widget>
-  <widget type="action_button" version="3.0.0">
-    <name>OpenDisplay</name>
-    <actions>
-      <action type="open_display">
-        <file>static_table_BigTable.bob</file>
-        <target>tab</target>
-        <description>Open Display</description>
-      </action>
-    </actions>
-    <text>Big Table &#10697;</text>
-    <x>22</x>
+  <widget type="group" version="2.0.0">
+    <name>Big Table</name>
+    <x>4</x>
     <y>54</y>
-    <width>248</width>
-    <height>20</height>
-    <tooltip>$(actions)</tooltip>
+    <width>279</width>
+    <height>150</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Heading</name>
+      <text>Binary Column</text>
+      <x>49</x>
+      <y>0</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font family="Liberation Sans" style="BOLD" size="16.0">
+      </font>
+      </font>
+      <foreground_color>
+        <color name="Header_ForeGround" red="255" green="255" blue="255">
+      </color>
+      </foreground_color>
+      <background_color>
+        <color name="Header_Background" red="77" green="77" blue="77">
+      </color>
+      </background_color>
+      <transparent>false</transparent>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Heading</name>
+      <text>Long Column</text>
+      <x>99</x>
+      <y>0</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font family="Liberation Sans" style="BOLD" size="16.0">
+      </font>
+      </font>
+      <foreground_color>
+        <color name="Header_ForeGround" red="255" green="255" blue="255">
+      </color>
+      </foreground_color>
+      <background_color>
+        <color name="Header_Background" red="77" green="77" blue="77">
+      </color>
+      </background_color>
+      <transparent>false</transparent>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Heading</name>
+      <text>Float Column</text>
+      <x>149</x>
+      <y>0</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font family="Liberation Sans" style="BOLD" size="16.0">
+      </font>
+      </font>
+      <foreground_color>
+        <color name="Header_ForeGround" red="255" green="255" blue="255">
+      </color>
+      </foreground_color>
+      <background_color>
+        <color name="Header_Background" red="77" green="77" blue="77">
+      </color>
+      </background_color>
+      <transparent>false</transparent>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Heading</name>
+      <text>String Column</text>
+      <x>199</x>
+      <y>0</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font family="Liberation Sans" style="BOLD" size="16.0">
+      </font>
+      </font>
+      <foreground_color>
+        <color name="Header_ForeGround" red="255" green="255" blue="255">
+      </color>
+      </foreground_color>
+      <background_color>
+        <color name="Header_Background" red="77" green="77" blue="77">
+      </color>
+      </background_color>
+      <transparent>false</transparent>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Row 1</text>
+      <x>0</x>
+      <y>24</y>
+      <width>45</width>
+      <height>20</height>
+      <tooltip>Row 1 - No description provided</tooltip>
+    </widget>
+    <widget type="led" version="2.0.0">
+      <name>LED</name>
+      <pv_name>$(P)$(R)BINARY_1</pv_name>
+      <x>62</x>
+      <y>24</y>
+      <width>20</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)LONG_1</pv_name>
+      <x>99</x>
+      <y>24</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)FLOAT_1</pv_name>
+      <x>149</x>
+      <y>24</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)STRING_1</pv_name>
+      <x>199</x>
+      <y>24</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Row 2</text>
+      <x>0</x>
+      <y>48</y>
+      <width>45</width>
+      <height>20</height>
+      <tooltip>Row 2 - No description provided</tooltip>
+    </widget>
+    <widget type="led" version="2.0.0">
+      <name>LED</name>
+      <pv_name>$(P)$(R)BINARY_2</pv_name>
+      <x>62</x>
+      <y>48</y>
+      <width>20</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)LONG_2</pv_name>
+      <x>99</x>
+      <y>48</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)FLOAT_2</pv_name>
+      <x>149</x>
+      <y>48</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)STRING_2</pv_name>
+      <x>199</x>
+      <y>48</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Row 3</text>
+      <x>0</x>
+      <y>72</y>
+      <width>45</width>
+      <height>20</height>
+      <tooltip>Row 3 - No description provided</tooltip>
+    </widget>
+    <widget type="led" version="2.0.0">
+      <name>LED</name>
+      <pv_name>$(P)$(R)BINARY_3</pv_name>
+      <x>62</x>
+      <y>72</y>
+      <width>20</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)LONG_3</pv_name>
+      <x>99</x>
+      <y>72</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)FLOAT_3</pv_name>
+      <x>149</x>
+      <y>72</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)STRING_3</pv_name>
+      <x>199</x>
+      <y>72</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Row 4</text>
+      <x>0</x>
+      <y>96</y>
+      <width>45</width>
+      <height>20</height>
+      <tooltip>Row 4 - No description provided</tooltip>
+    </widget>
+    <widget type="led" version="2.0.0">
+      <name>LED</name>
+      <pv_name>$(P)$(R)BINARY_4</pv_name>
+      <x>62</x>
+      <y>96</y>
+      <width>20</width>
+      <height>20</height>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)LONG_4</pv_name>
+      <x>99</x>
+      <y>96</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)FLOAT_4</pv_name>
+      <x>149</x>
+      <y>96</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)$(R)STRING_4</pv_name>
+      <x>199</x>
+      <y>96</y>
+      <width>46</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
   </widget>
 </display>

--- a/tests/format/output/static_table.edl
+++ b/tests/format/output/static_table.edl
@@ -5,8 +5,8 @@ minor 0
 release 1
 x 0
 y 0
-w 425
-h 80
+w 428
+h 200
 font "arial-bold-r-12.0"
 ctlFont "arial-bold-r-12.0"
 btnFont "arial-bold-r-12.0"
@@ -33,7 +33,7 @@ minor 1
 release 1
 x 0
 y 0
-w 425
+w 428
 h 25
 font "arial-bold-r-16.0"
 fontAlign "center"
@@ -81,25 +81,490 @@ lineWidth 2
 numBits 1
 endObjectProperties
 
-# (Extended Related Display)
-object ExtendedRelatedDisplayClass
+# (Rectangle)
+object activeRectangleClass
 beginObjectProperties
 major 4
 minor 0
 release 0
-x 10
+x 5
+y 60
+w 418
+h 135
+lineColor index 14
+fill
+fillColor index 5
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
 y 55
-w 410
-h 20
-fgColor index 25
-bgColor index 3
-topShadowColor index 1
-botShadowColor index 11
-font "arial-bold-r-12.0"
-numPvs 4
-numDsps 1
-displayFileName {
-  "0 static_table_BigTable"
+w 418
+h 10
+font "arial-medium-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "  Big Table  "
 }
-icon
+autoSize
+border
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 91
+y 70
+w 78
+h 20
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "Binary Column"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 174
+y 70
+w 78
+h 20
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "Long Column"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 257
+y 70
+w 78
+h 20
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "Float Column"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 340
+y 70
+w 78
+h 20
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 14
+bgColor index 8
+value {
+  "String Column"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 95
+w 76
+h 20
+font "arial-bold-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Row 1"
+}
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 95
+w 20
+h 20
+controlPv "$(P)$(R)BINARY_1"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+numBits 1
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 174
+y 95
+w 78
+h 20
+controlPv "$(P)$(R)LONG_1"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 257
+y 95
+w 78
+h 20
+controlPv "$(P)$(R)FLOAT_1"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 340
+y 95
+w 78
+h 20
+controlPv "$(P)$(R)STRING_1"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 120
+w 76
+h 20
+font "arial-bold-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Row 2"
+}
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 120
+w 20
+h 20
+controlPv "$(P)$(R)BINARY_2"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+numBits 1
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 174
+y 120
+w 78
+h 20
+controlPv "$(P)$(R)LONG_2"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 257
+y 120
+w 78
+h 20
+controlPv "$(P)$(R)FLOAT_2"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 340
+y 120
+w 78
+h 20
+controlPv "$(P)$(R)STRING_2"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 145
+w 76
+h 20
+font "arial-bold-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Row 3"
+}
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 145
+w 20
+h 20
+controlPv "$(P)$(R)BINARY_3"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+numBits 1
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 174
+y 145
+w 78
+h 20
+controlPv "$(P)$(R)LONG_3"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 257
+y 145
+w 78
+h 20
+controlPv "$(P)$(R)FLOAT_3"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 340
+y 145
+w 78
+h 20
+controlPv "$(P)$(R)STRING_3"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 170
+w 76
+h 20
+font "arial-bold-r-10.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Row 4"
+}
+endObjectProperties
+
+# (Byte)
+object ByteClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 120
+y 170
+w 20
+h 20
+controlPv "$(P)$(R)BINARY_4"
+lineColor index 14
+onColor index 15
+offColor index 19
+lineWidth 2
+numBits 1
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 174
+y 170
+w 78
+h 20
+controlPv "$(P)$(R)LONG_4"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 257
+y 170
+w 78
+h 20
+controlPv "$(P)$(R)FLOAT_4"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 340
+y 170
+w 78
+h 20
+controlPv "$(P)$(R)STRING_4"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
 endObjectProperties

--- a/tests/reconvert/output/simDetector.pvi.device.yaml
+++ b/tests/reconvert/output/simDetector.pvi.device.yaml
@@ -5,6 +5,7 @@ children:
     layout:
       type: Grid
       labelled: true
+      stacked: false
     children:
       - type: SignalW
         name: ResetPower
@@ -336,6 +337,7 @@ children:
     layout:
       type: Grid
       labelled: true
+      stacked: false
     children:
       - type: SignalRW
         name: Mode

--- a/tests/test.pvi.device.yaml
+++ b/tests/test.pvi.device.yaml
@@ -5,6 +5,7 @@ children:
     layout:
       type: Grid
       labelled: true
+      stacked: false
     children:
       - type: SignalW
         name: WidthUnits


### PR DESCRIPTION
Moved from branch table-cells

reimplemented logic from other branch
- removed cell component
- added 'stacked' boolean, default = false
- now defined at the top level (of any Group not just table)
- will apply to any SignalRW within that group
- tables are squeezed when defined inline to match width of regular groups
- tables in subscreens now have widget width that matches widget width in groups

Usage:
```
  - type: Group
    name: RoiTable
    label: ROI Table
    layout:
      type: Grid
      labelled: true
      stacked: true
    children:
      - type: Group
        name: RoiEnableRow
        label: Enable
        layout:
          type: Row
          header:
            - ROI1
            - ROI2
            - ROI3
            - ROI4
        children:
          - type: SignalRW
            name: Roi1Enable
            write_pv: $(P)$(R)ROI1:Enable
            write_widget:
              type: ComboBox
              choices:
                - Disable
                - Enable
            read_pv: $(P)$(R)ROI1:Enable_RBV
            read_widget:
              type: LED
...
```

Example with:
- regular group
- group with stacked widgets
- 2 column table
- 3 column table with stacked widgets
- 4 column table with stacked widgets
- same 4 column table with stacked widgets in a subscreen

<img width="1479" height="931" alt="Screenshot from 2026-04-01 15-35-03" src="https://github.com/user-attachments/assets/f6b5ee2e-6ff4-4659-aef7-c52ad94d7ca8" />

<img width="1182" height="301" alt="Screenshot from 2026-04-01 15-35-32" src="https://github.com/user-attachments/assets/92d98aeb-0181-4612-8608-33477bfd288e" />
