### PR TITLE
Fix: preserve group label through SubScreen reconstructions

### DIFF
--- a/src/pvi/_format/dls.py
+++ b/src/pvi/_format/dls.py
@@ -27,7 +27,7 @@ from pvi._format.widget import (
 from pvi.device import Device
 
 from .base import Formatter
-from .utils import Bounds, with_title
+from .utils import Bounds, with_title, without_title
 
 
 class DLSFormatter(Formatter):
@@ -353,12 +353,21 @@ class DLSFormatter(Formatter):
             ]
 
         # SCREEN_INI DOCS REF: Construct a screen object
+        title = f"{device.label}"
+        has_title = bool(title)
+
         formatter_factory: ScreenFormatterFactory[_Element] = ScreenFormatterFactory(
             screen_formatter_cls=GroupFormatter[_Element].from_template(
                 template,
                 search=GroupType.SCREEN,
-                sized=with_title(screen_layout.spacing, screen_layout.title_height),
-                widget_formatter_hook=create_screen_title_formatter,
+                sized=(
+                    with_title(screen_layout.spacing, screen_layout.title_height)
+                    if has_title
+                    else without_title(screen_layout.spacing)
+                ),
+                widget_formatter_hook=(
+                    create_screen_title_formatter if has_title else None
+                ),
             ),
             group_formatter_cls=GroupFormatter[_Element].from_template(
                 template,
@@ -373,8 +382,6 @@ class DLSFormatter(Formatter):
             base_file_name=path.stem,
         )
         # SCREEN_FORMAT DOCS REF: Format the screen
-        title = f"{device.label}"
-
         screen_formatter, sub_screens = formatter_factory.create_screen_formatter(
             device.children, title
         )

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -530,6 +530,10 @@ class ScreenFormatterFactory(Generic[T]):
                     component_bounds.h *= 10  # TODO: How do we know the number of rows?
                 case SignalR(read_widget=ImageRead() | ArrayTrace()):
                     add_label = False
+                case DeviceRef():
+                    # DeviceRef buttons are self-identifying; the label is
+                    # shown as the button text so no separate label is needed.
+                    add_label = False
                 case _:
                     pass
 
@@ -603,7 +607,7 @@ class ScreenFormatterFactory(Generic[T]):
             elif isinstance(rc, DeviceRef):
                 yield self.widget_formatter_factory.sub_screen_formatter_cls(
                     bounds=rc_bounds,
-                    label=" ".join(rc.macros.values()),
+                    label=rc.get_label(),
                     file_name=rc.ui,
                     macros=rc.macros,
                 )

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -252,7 +252,7 @@ class ScreenFormatterFactory(Generic[T]):
         """
         if isinstance(c.layout, SubScreen):
             return self.create_component_widget_formatters(
-                Group(name=c.name, layout=c.layout, children=c.children),
+                Group(name=c.name, label=c.label, layout=c.layout, children=c.children),
                 parent_bounds=screen_bounds,
                 column_bounds=column_bounds,
                 next_column_bounds=next_column_bounds,
@@ -631,7 +631,10 @@ def is_table(component: Group) -> bool:
 
 def move_to_subscreen(component: ComponentUnion) -> Group:
     return Group(
-        name=component.name, layout=SubScreen(labelled=False), children=[component]
+        name=component.name,
+        label=component.label if isinstance(component, Group) else None,
+        layout=SubScreen(labelled=False),
+        children=[component],
     )
 
 

--- a/src/pvi/_format/utils.py
+++ b/src/pvi/_format/utils.py
@@ -99,3 +99,7 @@ def with_title(spacing: int, title_height: int) -> Callable[[Bounds], Bounds]:
     return Bounds(
         x=spacing, y=spacing + title_height, w=2 * spacing, h=2 * spacing + title_height
     ).added_to
+
+
+def without_title(spacing: int) -> Callable[[Bounds], Bounds]:
+    return Bounds(x=spacing, y=spacing, w=2 * spacing, h=2 * spacing).added_to

--- a/tests/format/output/device_ref.bob
+++ b/tests/format/output/device_ref.bob
@@ -29,19 +29,6 @@
     <transparent use_class="true">true</transparent>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>Combo Box</text>
-    <x>22</x>
-    <y>30</y>
-    <width>120</width>
-    <height>20</height>
-    <font>
-      <font family="Cantarell" style="REGULAR" size="14.0">
-      </font>
-    </font>
-    <tooltip>Combo Box - No description provided</tooltip>
-  </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
     <actions>

--- a/tests/format/output/device_ref.bob
+++ b/tests/format/output/device_ref.bob
@@ -25,15 +25,6 @@
     <transparent use_class="true">true</transparent>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>Combo Box</text>
-    <x>22</x>
-    <y>30</y>
-    <width>120</width>
-    <height>20</height>
-    <tooltip>Combo Box - No description provided</tooltip>
-  </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
     <actions>
@@ -46,10 +37,10 @@
         </macros>
       </action>
     </actions>
-    <text>TEST:</text>
-    <x>146</x>
+    <text>Combo Box</text>
+    <x>22</x>
     <y>30</y>
-    <width>124</width>
+    <width>248</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
   </widget>

--- a/tests/format/output/group_label_preserved.bob
+++ b/tests/format/output/group_label_preserved.bob
@@ -1,0 +1,75 @@
+<display version="2.0.0">
+  <name>Label Test - $(P)</name>
+  <x>0</x>
+  <y use_class="true">0</y>
+  <width>274</width>
+  <height>78</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Label Test - $(P)</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>274</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Other Sig</text>
+    <x>22</x>
+    <y>30</y>
+    <width>120</width>
+    <height>20</height>
+    <tooltip>Other Sig - No description provided</tooltip>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>TextUpdate</name>
+    <pv_name>$(P)Other</pv_name>
+    <x>146</x>
+    <y>30</y>
+    <width>124</width>
+    <height>20</height>
+    <font>
+      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+    </font>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>BL04I-EA-E1RIO-01</text>
+    <x>22</x>
+    <y>54</y>
+    <width>120</width>
+    <height>20</height>
+    <tooltip>BL04I-EA-E1RIO-01 - No description provided</tooltip>
+  </widget>
+  <widget type="action_button" version="3.0.0">
+    <name>OpenDisplay</name>
+    <actions>
+      <action type="open_display">
+        <file>group_label_preserved_Bl04iEaErio01.bob</file>
+        <target>tab</target>
+        <description>Open Display</description>
+      </action>
+    </actions>
+    <text>BL04I-EA-E1RIO-01 &#10697;</text>
+    <x>146</x>
+    <y>54</y>
+    <width>124</width>
+    <height>20</height>
+    <tooltip>$(actions)</tooltip>
+  </widget>
+</display>

--- a/tests/format/output/group_label_preserved.bob
+++ b/tests/format/output/group_label_preserved.bob
@@ -4,6 +4,10 @@
   <y use_class="true">0</y>
   <width>274</width>
   <height>78</height>
+  <background_color>
+    <color red="245" green="247" blue="250">
+    </color>
+  </background_color>
   <grid_step_x>4</grid_step_x>
   <grid_step_y>4</grid_step_y>
   <widget type="label" version="2.0.0">
@@ -32,6 +36,10 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
+    <font>
+      <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+    </font>
     <tooltip>Other Sig - No description provided</tooltip>
   </widget>
   <widget type="textupdate" version="2.0.0">
@@ -42,10 +50,22 @@
     <width>124</width>
     <height>20</height>
     <font>
-      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      <font family="Cantarell" style="BOLD" size="14.0">
       </font>
     </font>
+    <foreground_color>
+      <color red="15" green="23" blue="42">
+      </color>
+    </foreground_color>
+    <background_color>
+      <color red="245" green="247" blue="250">
+      </color>
+    </background_color>
     <horizontal_alignment>1</horizontal_alignment>
+    <border_color>
+      <color red="203" green="213" blue="225">
+      </color>
+    </border_color>
   </widget>
   <widget type="label" version="2.0.0">
     <name>Label</name>
@@ -54,15 +74,19 @@
     <y>54</y>
     <width>120</width>
     <height>20</height>
+    <font>
+      <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+    </font>
     <tooltip>BL04I-EA-E1RIO-01 - No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
     <actions>
       <action type="open_display">
+        <description>Open Display</description>
         <file>group_label_preserved_Bl04iEaErio01.bob</file>
         <target>tab</target>
-        <description>Open Display</description>
       </action>
     </actions>
     <text>BL04I-EA-E1RIO-01 &#10697;</text>
@@ -70,6 +94,18 @@
     <y>54</y>
     <width>124</width>
     <height>20</height>
+    <font>
+      <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+    </font>
+    <foreground_color>
+      <color red="37" green="99" blue="235">
+      </color>
+    </foreground_color>
+    <background_color>
+      <color red="241" green="245" blue="249">
+      </color>
+    </background_color>
     <tooltip>$(actions)</tooltip>
   </widget>
 </display>

--- a/tests/format/output/group_label_preserved_Bl04iEaErio01.bob
+++ b/tests/format/output/group_label_preserved_Bl04iEaErio01.bob
@@ -1,0 +1,50 @@
+<display version="2.0.0">
+  <name>Bl04iEaErio01</name>
+  <x>0</x>
+  <y use_class="true">0</y>
+  <width>274</width>
+  <height>54</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Bl04iEaErio01</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>274</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="label" version="2.0.0">
+    <name>Label</name>
+    <text>Status</text>
+    <x>22</x>
+    <y>30</y>
+    <width>120</width>
+    <height>20</height>
+    <tooltip>Status - No description provided</tooltip>
+  </widget>
+  <widget type="textupdate" version="2.0.0">
+    <name>TextUpdate</name>
+    <pv_name>$(P)BL04I:EA:E1RIO01:Status</pv_name>
+    <x>146</x>
+    <y>30</y>
+    <width>124</width>
+    <height>20</height>
+    <font>
+      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+    </font>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+</display>

--- a/tests/format/output/group_label_preserved_Bl04iEaErio01.bob
+++ b/tests/format/output/group_label_preserved_Bl04iEaErio01.bob
@@ -4,6 +4,10 @@
   <y use_class="true">0</y>
   <width>274</width>
   <height>54</height>
+  <background_color>
+    <color red="245" green="247" blue="250">
+    </color>
+  </background_color>
   <grid_step_x>4</grid_step_x>
   <grid_step_y>4</grid_step_y>
   <widget type="label" version="2.0.0">
@@ -32,6 +36,10 @@
     <y>30</y>
     <width>120</width>
     <height>20</height>
+    <font>
+      <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+    </font>
     <tooltip>Status - No description provided</tooltip>
   </widget>
   <widget type="textupdate" version="2.0.0">
@@ -42,9 +50,21 @@
     <width>124</width>
     <height>20</height>
     <font>
-      <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      <font family="Cantarell" style="BOLD" size="14.0">
       </font>
     </font>
+    <foreground_color>
+      <color red="15" green="23" blue="42">
+      </color>
+    </foreground_color>
+    <background_color>
+      <color red="245" green="247" blue="250">
+      </color>
+    </background_color>
     <horizontal_alignment>1</horizontal_alignment>
+    <border_color>
+      <color red="203" green="213" blue="225">
+      </color>
+    </border_color>
   </widget>
 </display>

--- a/tests/format/output/index.bob
+++ b/tests/format/output/index.bob
@@ -25,15 +25,6 @@
     <transparent use_class="true">true</transparent>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>Button - $(P)</text>
-    <x>23</x>
-    <y>30</y>
-    <width>200</width>
-    <height>20</height>
-    <tooltip>Button - $(P) - No description provided</tooltip>
-  </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
     <actions>
@@ -46,21 +37,12 @@
         </macros>
       </action>
     </actions>
-    <text>TEST:</text>
-    <x>228</x>
+    <text>Button - $(P)</text>
+    <x>23</x>
     <y>30</y>
-    <width>205</width>
+    <width>410</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>ComboBox</text>
-    <x>23</x>
-    <y>55</y>
-    <width>200</width>
-    <height>20</height>
-    <tooltip>ComboBox - No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
@@ -74,21 +56,12 @@
         </macros>
       </action>
     </actions>
-    <text>TEST:</text>
-    <x>228</x>
+    <text>ComboBox</text>
+    <x>23</x>
     <y>55</y>
-    <width>205</width>
+    <width>410</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>table</text>
-    <x>23</x>
-    <y>80</y>
-    <width>200</width>
-    <height>20</height>
-    <tooltip>table - No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
@@ -102,10 +75,10 @@
         </macros>
       </action>
     </actions>
-    <text>TEST:</text>
-    <x>228</x>
+    <text>table</text>
+    <x>23</x>
     <y>80</y>
-    <width>205</width>
+    <width>410</width>
     <height>20</height>
     <tooltip>$(actions)</tooltip>
   </widget>

--- a/tests/format/output/index.bob
+++ b/tests/format/output/index.bob
@@ -29,19 +29,6 @@
     <transparent use_class="true">true</transparent>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>Button - $(P)</text>
-    <x>23</x>
-    <y>30</y>
-    <width>200</width>
-    <height>20</height>
-    <font>
-      <font family="Cantarell" style="REGULAR" size="14.0">
-      </font>
-    </font>
-    <tooltip>Button - $(P) - No description provided</tooltip>
-  </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
     <actions>
@@ -73,19 +60,6 @@
     </background_color>
     <tooltip>$(actions)</tooltip>
   </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>ComboBox</text>
-    <x>23</x>
-    <y>55</y>
-    <width>200</width>
-    <height>20</height>
-    <font>
-      <font family="Cantarell" style="REGULAR" size="14.0">
-      </font>
-    </font>
-    <tooltip>ComboBox - No description provided</tooltip>
-  </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>
     <actions>
@@ -116,19 +90,6 @@
       </color>
     </background_color>
     <tooltip>$(actions)</tooltip>
-  </widget>
-  <widget type="label" version="2.0.0">
-    <name>Label</name>
-    <text>table</text>
-    <x>23</x>
-    <y>80</y>
-    <width>200</width>
-    <height>20</height>
-    <font>
-      <font family="Cantarell" style="REGULAR" size="14.0">
-      </font>
-    </font>
-    <tooltip>table - No description provided</tooltip>
   </widget>
   <widget type="action_button" version="3.0.0">
     <name>OpenDisplay</name>

--- a/tests/format/output/stacked.bob
+++ b/tests/format/output/stacked.bob
@@ -4,6 +4,10 @@
   <y use_class="true">0</y>
   <width>290</width>
   <height>136</height>
+  <background_color>
+    <color red="245" green="247" blue="250">
+    </color>
+  </background_color>
   <grid_step_x>4</grid_step_x>
   <grid_step_y>4</grid_step_y>
   <widget type="label" version="2.0.0">
@@ -25,12 +29,20 @@
     <transparent use_class="true">true</transparent>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
-  <widget type="group" version="2.0.0">
+  <widget type="group" version="3.0.0">
     <name>Stacked Group</name>
     <x>4</x>
     <y>30</y>
     <width>282</width>
     <height>102</height>
+    <font>
+      <font family="Cantarell" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <background_color>
+      <color red="246" green="247" blue="249">
+      </color>
+    </background_color>
     <transparent>true</transparent>
     <widget type="label" version="2.0.0">
       <name>Label</name>
@@ -39,6 +51,10 @@
       <y>0</y>
       <width>120</width>
       <height>44</height>
+      <font>
+        <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+      </font>
       <tooltip>Stacked Read Write - An RW with a TextRead widget, so it stacks</tooltip>
     </widget>
     <widget type="textentry" version="3.0.0">
@@ -48,6 +64,14 @@
       <y>0</y>
       <width>124</width>
       <height>20</height>
+      <font>
+        <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+      </font>
+      <background_color>
+        <color red="229" green="235" blue="255">
+      </color>
+      </background_color>
       <horizontal_alignment>1</horizontal_alignment>
     </widget>
     <widget type="textupdate" version="2.0.0">
@@ -58,10 +82,22 @@
       <width>124</width>
       <height>20</height>
       <font>
-        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        <font family="Cantarell" style="BOLD" size="14.0">
       </font>
       </font>
+      <foreground_color>
+        <color red="15" green="23" blue="42">
+      </color>
+      </foreground_color>
+      <background_color>
+        <color red="245" green="247" blue="250">
+      </color>
+      </background_color>
       <horizontal_alignment>1</horizontal_alignment>
+      <border_color>
+        <color red="203" green="213" blue="225">
+      </color>
+      </border_color>
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
@@ -70,6 +106,10 @@
       <y>48</y>
       <width>120</width>
       <height>20</height>
+      <font>
+        <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+      </font>
       <tooltip>Unstacked Read Write - An RW with a non-TextRead widget, so it does not stack</tooltip>
     </widget>
     <widget type="textentry" version="3.0.0">
@@ -79,6 +119,14 @@
       <y>48</y>
       <width>60</width>
       <height>20</height>
+      <font>
+        <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+      </font>
+      <background_color>
+        <color red="229" green="235" blue="255">
+      </color>
+      </background_color>
       <horizontal_alignment>1</horizontal_alignment>
     </widget>
     <widget type="led" version="2.0.0">
@@ -88,6 +136,21 @@
       <y>48</y>
       <width>20</width>
       <height>20</height>
+      <off_label>&#9675;</off_label>
+      <off_color>
+        <color red="22" green="163" blue="74">
+      </color>
+      </off_color>
+      <on_label>&#9679;</on_label>
+      <on_color>
+        <color red="167" green="243" blue="208">
+      </color>
+      </on_color>
+      <font>
+        <font family="Cantarell" style="BOLD" size="12.0">
+      </font>
+      </font>
+      <square>true</square>
     </widget>
   </widget>
 </display>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -291,3 +291,41 @@ def test_pvi_template(tmp_path, helper):
     format_template(device, "$(P)", output_template)
 
     helper.assert_output_matches(expected_bob, output_template)
+
+
+def test_group_label_preserved_through_subscreen(tmp_path, helper):
+    """Group.label must survive SubScreen reconstruction.
+
+    When create_group_formatters reconstructs a Group for SubScreen layout, and
+    when move_to_subscreen wraps a Group in a SubScreen, both must forward the
+    original label rather than letting it default to None.  Without the fix,
+    get_label() falls back to to_title_case(name) and a name like
+    "Bl04iEaErio01" would produce "Bl 04i Ea Erio 01" instead of the intended
+    "BL04I-EA-E1RIO-01".
+    """
+    formatter_yaml = HERE / "format" / "input" / "dls.bob.pvi.formatter.yaml"
+    formatter = Formatter.deserialize(formatter_yaml)
+
+    # A sibling signal forces the SubScreen group through create_group_formatters
+    # rather than the single-group special-case expansion of create_screen_formatter,
+    # so the SubScreen button is rendered and its label can be verified.
+    labeled_sub = Group(
+        name="Bl04iEaErio01",
+        label="BL04I-EA-E1RIO-01",
+        layout=SubScreen(),
+        children=[
+            SignalR(
+                name="Status",
+                read_pv="$(P)BL04I:EA:E1RIO01:Status",
+                read_widget=TextRead(),
+            ),
+        ],
+    )
+    sibling = SignalR(name="OtherSig", read_pv="$(P)Other", read_widget=TextRead())
+    device = Device(label="Label Test - $(P)", children=[sibling, labeled_sub])
+
+    expected_bob = HERE / "format" / "output" / "group_label_preserved.bob"
+    output_bob = tmp_path / "group_label_preserved.bob"
+    formatter.format(device, output_bob)
+
+    helper.assert_output_matches(expected_bob, output_bob)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -294,14 +294,13 @@ def test_pvi_template(tmp_path, helper):
 
 
 def test_group_label_preserved_through_subscreen(tmp_path, helper):
-    """Group.label must survive SubScreen reconstruction.
+    """Group.label must survive SubScreen reconstruction in create_group_formatters.
 
-    When create_group_formatters reconstructs a Group for SubScreen layout, and
-    when move_to_subscreen wraps a Group in a SubScreen, both must forward the
-    original label rather than letting it default to None.  Without the fix,
-    get_label() falls back to to_title_case(name) and a name like
-    "Bl04iEaErio01" would produce "Bl 04i Ea Erio 01" instead of the intended
-    "BL04I-EA-E1RIO-01".
+    When create_group_formatters reconstructs a Group for SubScreen layout it
+    must forward the original label rather than letting it default to None.
+    Without the fix, get_label() falls back to to_title_case(name) and a name
+    like "Bl04iEaErio01" would produce "Bl 04i Ea Erio 01" instead of the
+    intended "BL04I-EA-E1RIO-01".
     """
     formatter_yaml = HERE / "format" / "input" / "dls.bob.pvi.formatter.yaml"
     formatter = Formatter.deserialize(formatter_yaml)


### PR DESCRIPTION
### Allows upstream callers (e.g. fastcs) to set a display label independently of the group name.

When a [Group] is reconstructed during screen layout — in `create_group_formatters` and `move_to_subscreen` — the `label` field was being silently dropped. `get_label()` then falls back to `to_title_case(name)`, mangling display names like "BL04I-EA-E1RIO-01" into "Bl 04i Ea E1rio 01".
Also the label is optimised at render time for `DeviceRef` buttons and absent label at the device level are handled.

**Changes**
`create_group_formatters`: pass `label=c.label` when reconstructing the `Group` for `SubScreen` layout
`move_to_subscreen`: pass `label=component.label if isinstance(component, Group) else None` when wrapping a component in a `SubScreen` group
`screen.py` (ScreenFormatterFactory): for `DeviceRef` components, use `rc.get_label()` as the button text (instead of joining the macros dict values, which was often empty and fell back to the widget default 'SubScreen'), and set `add_label=False` to suppress the redundant adjacent label widget — giving a clean full-width button whose text matches the PV name emitted by fastcs.
`dls.py` / `utils.py`: add a `without_title()` sizing helper (mirroring `with_title()`) and use it in `format_bob()` when `device.label` is empty, skipping both the title widget and the vertical space it would have occupied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved screen rendering so title spacing is only applied when a screen actually has a title.

- **Bug Fixes**
  - Fixed label behavior for Device Reference controls in sub-screen layouts, ensuring the correct button label text and consistent positioning/sizing.
  - Updated action button label areas and corrected combo box label widget layout to match expected output.

- **Tests**
  - Added/updated golden output fixtures and introduced a test to verify explicit group labels are preserved through SubScreen formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->