### PR TITLE
Fix: flatten nested grid groups instead of raising NotImplementedError

### DIFF
--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -332,7 +332,7 @@ class ScreenFormatterFactory(Generic[T]):
                 case Group(layout=SubScreen(labelled=labelled)):
                     add_label = labelled
                     component = c
-                case Group(layout=Grid(labelled=labelled)):
+                case Group(layout=Grid(labelled=labelled, stacked=inner_stacked)):
                     # PVI cannot render a Grid inside another Grid as a nested group.
                     # Flatten the inner Grid's children directly into the parent, which
                     # is equivalent to merging the two Grid sections on the same screen.
@@ -354,9 +354,8 @@ class ScreenFormatterFactory(Generic[T]):
                                 parent_bounds=bounds,
                                 column_bounds=column_bounds,
                                 next_column_bounds=next_column_bounds,
-                                add_label=True,
-                                stacked=isinstance(group.layout, Grid)
-                                and group.layout.stacked,
+                                add_label=labelled,
+                                stacked=inner_stacked,
                                 squeeze=squeeze,
                             )
                         )

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -332,10 +332,32 @@ class ScreenFormatterFactory(Generic[T]):
                     add_label = labelled
                     component = c
                 case Group(layout=Grid(labelled=labelled)):
-                    add_label = labelled
-                    raise NotImplementedError(
-                        "Cannot nest a Group(Grid()) in another Group on one screen"
-                    )
+                    # PVI cannot render a Grid inside another Grid as a nested group.
+                    # Flatten the inner Grid's children directly into the parent, which
+                    # is equivalent to merging the two Grid sections on the same screen.
+                    for nested_child in c.children:
+                        if isinstance(nested_child, IgnoredComponent):
+                            continue
+                        next_column_bounds = Bounds(
+                            x=next_x(widget_factories, self.layout.spacing),
+                            w=full_w,
+                            h=self.layout.widget_height,
+                        )
+                        widget_factories.extend(
+                            self.create_component_widget_formatters(
+                                nested_child,
+                                parent_bounds=bounds,
+                                column_bounds=column_bounds,
+                                next_column_bounds=next_column_bounds,
+                                add_label=True,
+                                stacked=isinstance(group.layout, Grid)
+                                and group.layout.stacked,
+                                squeeze=squeeze,
+                            )
+                        )
+                        if next_column_bounds.y != 0:
+                            column_bounds = next_column_bounds
+                    continue
                 case _:
                     # Make single line with a component or Row of components
                     component = c

--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -338,6 +338,10 @@ class ScreenFormatterFactory(Generic[T]):
                     for nested_child in c.children:
                         if isinstance(nested_child, IgnoredComponent):
                             continue
+                        if _has_plot_widget(nested_child):
+                            # Promote waveform/image signals to SubScreen buttons,
+                            # matching split_out_plots behaviour at the top level.
+                            nested_child = move_to_subscreen(nested_child)
                         next_column_bounds = Bounds(
                             x=next_x(widget_factories, self.layout.spacing),
                             w=full_w,

--- a/tests/format/output/nested_grid_flattened.bob
+++ b/tests/format/output/nested_grid_flattened.bob
@@ -1,0 +1,102 @@
+<display version="2.0.0">
+  <name>Grid Flatten Test - $(P)</name>
+  <x>0</x>
+  <y use_class="true">0</y>
+  <width>290</width>
+  <height>136</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Grid Flatten Test - $(P)</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>290</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Outer Group</name>
+    <x>4</x>
+    <y>30</y>
+    <width>282</width>
+    <height>102</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Direct Signal</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Direct Signal - No description provided</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)Direct</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Nested A</text>
+      <x>0</x>
+      <y>24</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Nested A - No description provided</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)Nested:A</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Nested B</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Nested B - No description provided</tooltip>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>$(P)Nested:B</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+  </widget>
+</display>

--- a/tests/format/output/nested_grid_flattened.bob
+++ b/tests/format/output/nested_grid_flattened.bob
@@ -4,6 +4,10 @@
   <y use_class="true">0</y>
   <width>290</width>
   <height>136</height>
+  <background_color>
+    <color red="245" green="247" blue="250">
+    </color>
+  </background_color>
   <grid_step_x>4</grid_step_x>
   <grid_step_y>4</grid_step_y>
   <widget type="label" version="2.0.0">
@@ -25,12 +29,20 @@
     <transparent use_class="true">true</transparent>
     <horizontal_alignment>1</horizontal_alignment>
   </widget>
-  <widget type="group" version="2.0.0">
+  <widget type="group" version="3.0.0">
     <name>Outer Group</name>
     <x>4</x>
     <y>30</y>
     <width>282</width>
     <height>102</height>
+    <font>
+      <font family="Cantarell" style="REGULAR" size="16.0">
+      </font>
+    </font>
+    <background_color>
+      <color red="246" green="247" blue="249">
+      </color>
+    </background_color>
     <transparent>true</transparent>
     <widget type="label" version="2.0.0">
       <name>Label</name>
@@ -39,6 +51,10 @@
       <y>0</y>
       <width>120</width>
       <height>20</height>
+      <font>
+        <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+      </font>
       <tooltip>Direct Signal - No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
@@ -49,10 +65,22 @@
       <width>124</width>
       <height>20</height>
       <font>
-        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        <font family="Cantarell" style="BOLD" size="14.0">
       </font>
       </font>
+      <foreground_color>
+        <color red="15" green="23" blue="42">
+      </color>
+      </foreground_color>
+      <background_color>
+        <color red="245" green="247" blue="250">
+      </color>
+      </background_color>
       <horizontal_alignment>1</horizontal_alignment>
+      <border_color>
+        <color red="203" green="213" blue="225">
+      </color>
+      </border_color>
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
@@ -61,6 +89,10 @@
       <y>24</y>
       <width>120</width>
       <height>20</height>
+      <font>
+        <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+      </font>
       <tooltip>Nested A - No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
@@ -71,10 +103,22 @@
       <width>124</width>
       <height>20</height>
       <font>
-        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        <font family="Cantarell" style="BOLD" size="14.0">
       </font>
       </font>
+      <foreground_color>
+        <color red="15" green="23" blue="42">
+      </color>
+      </foreground_color>
+      <background_color>
+        <color red="245" green="247" blue="250">
+      </color>
+      </background_color>
       <horizontal_alignment>1</horizontal_alignment>
+      <border_color>
+        <color red="203" green="213" blue="225">
+      </color>
+      </border_color>
     </widget>
     <widget type="label" version="2.0.0">
       <name>Label</name>
@@ -83,6 +127,10 @@
       <y>48</y>
       <width>120</width>
       <height>20</height>
+      <font>
+        <font family="Cantarell" style="REGULAR" size="14.0">
+      </font>
+      </font>
       <tooltip>Nested B - No description provided</tooltip>
     </widget>
     <widget type="textupdate" version="2.0.0">
@@ -93,10 +141,22 @@
       <width>124</width>
       <height>20</height>
       <font>
-        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+        <font family="Cantarell" style="BOLD" size="14.0">
       </font>
       </font>
+      <foreground_color>
+        <color red="15" green="23" blue="42">
+      </color>
+      </foreground_color>
+      <background_color>
+        <color red="245" green="247" blue="250">
+      </color>
+      </background_color>
       <horizontal_alignment>1</horizontal_alignment>
+      <border_color>
+        <color red="203" green="213" blue="225">
+      </color>
+      </border_color>
     </widget>
   </widget>
 </display>

--- a/tests/format/output/nested_grid_flattened.bob
+++ b/tests/format/output/nested_grid_flattened.bob
@@ -82,25 +82,12 @@
       </color>
       </border_color>
     </widget>
-    <widget type="label" version="2.0.0">
-      <name>Label</name>
-      <text>Nested A</text>
-      <x>0</x>
-      <y>24</y>
-      <width>120</width>
-      <height>20</height>
-      <font>
-        <font family="Cantarell" style="REGULAR" size="14.0">
-      </font>
-      </font>
-      <tooltip>Nested A - No description provided</tooltip>
-    </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)Nested:A</pv_name>
-      <x>124</x>
+      <x>0</x>
       <y>24</y>
-      <width>124</width>
+      <width>248</width>
       <height>20</height>
       <font>
         <font family="Cantarell" style="BOLD" size="14.0">
@@ -120,25 +107,12 @@
       </color>
       </border_color>
     </widget>
-    <widget type="label" version="2.0.0">
-      <name>Label</name>
-      <text>Nested B</text>
-      <x>0</x>
-      <y>48</y>
-      <width>120</width>
-      <height>20</height>
-      <font>
-        <font family="Cantarell" style="REGULAR" size="14.0">
-      </font>
-      </font>
-      <tooltip>Nested B - No description provided</tooltip>
-    </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)Nested:B</pv_name>
-      <x>124</x>
+      <x>0</x>
       <y>48</y>
-      <width>124</width>
+      <width>248</width>
       <height>20</height>
       <font>
         <font family="Cantarell" style="BOLD" size="14.0">

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -291,3 +291,45 @@ def test_pvi_template(tmp_path, helper):
     format_template(device, "$(P)", output_template)
 
     helper.assert_output_matches(expected_bob, output_template)
+
+
+def test_nested_grid_groups_flattened(tmp_path, helper):
+    """A Grid group nested inside another Grid group must be flattened, not raise.
+
+    fastcs emits attribute sub-groups as Group(Grid()).  When a controller with
+    INLINE (Grid) group_layout also has such attribute groups, PVI would
+    previously raise NotImplementedError.  The fix flattens the inner Grid's
+    children directly into the parent Group as individual rows.
+    """
+    formatter_yaml = HERE / "format" / "input" / "dls.bob.pvi.formatter.yaml"
+    formatter = Formatter.deserialize(formatter_yaml)
+
+    # Outer Grid group containing an inner Grid group — the formerly forbidden nesting.
+    outer = Group(
+        name="OuterGroup",
+        label="Outer Group",
+        layout=Grid(),
+        children=[
+            SignalR(name="DirectSignal", read_pv="$(P)Direct", read_widget=TextRead()),
+            Group(
+                name="InnerGroup",
+                label="Inner Group",
+                layout=Grid(),
+                children=[
+                    SignalR(
+                        name="NestedA", read_pv="$(P)Nested:A", read_widget=TextRead()
+                    ),
+                    SignalR(
+                        name="NestedB", read_pv="$(P)Nested:B", read_widget=TextRead()
+                    ),
+                ],
+            ),
+        ],
+    )
+    device = Device(label="Grid Flatten Test - $(P)", children=[outer])
+
+    expected_bob = HERE / "format" / "output" / "nested_grid_flattened.bob"
+    output_bob = tmp_path / "nested_grid_flattened.bob"
+    formatter.format(device, output_bob)
+
+    helper.assert_output_matches(expected_bob, output_bob)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -314,7 +314,7 @@ def test_nested_grid_groups_flattened(tmp_path, helper):
             Group(
                 name="InnerGroup",
                 label="Inner Group",
-                layout=Grid(),
+                layout=Grid(labelled=False, stacked=True),
                 children=[
                     SignalR(
                         name="NestedA", read_pv="$(P)Nested:A", read_widget=TextRead()


### PR DESCRIPTION
### Prevent any `INLINE` sub-controller containing grouped attributes to fail unconditionally.

When a `Group(Grid())` appears as a child inside `create_group_formatter`, the code previously raised `NotImplementedError("Cannot nest a Group(Grid()) in another Group on one screen")`. This is triggered whenever a controller with `INLINE` (Grid) group layout contains attribute sub-groups, which fastcs always emits as `Group(Grid())` objects.

**Change**
Instead of raising, iterate the inner `Grid`'s children and inject them directly as individual rows into the parent group formatter. This is semantically equivalent to merging the two grid sections on the same screen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nested grid layouts are now supported without errors.
  * Items inside nested grids are automatically flattened into the parent layout while preserving their positioning and display settings.

* **Tests**
  * Added regression coverage to verify correct output for nested grid groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->