### PR TITLE
Change conditionals to only stack SignalRW with TextRead widget

### DIFF
--- a/src/pvi/_format/screen.py
+++ b/src/pvi/_format/screen.py
@@ -38,6 +38,7 @@ from pvi.device import (
     SubScreen,
     TableRead,
     TableWrite,
+    TextRead,
     Tree,
 )
 
@@ -409,7 +410,9 @@ class ScreenFormatterFactory(Generic[T]):
         if isinstance(c, SignalR) and isinstance(c.read_widget, ImageRead | ArrayTrace):
             tmp_column_bounds.w = c.read_widget.width
             tmp_column_bounds.h = c.read_widget.height
-        elif stacked and isinstance(c, SignalRW) and c.read_widget is not None:
+        elif (
+            stacked and isinstance(c, SignalRW) and isinstance(c.read_widget, TextRead)
+        ):
             tmp_column_bounds.h = 2 * self.layout.widget_height + self.layout.spacing
             tmp_next_column_bounds.h = tmp_column_bounds.h
 
@@ -502,7 +505,7 @@ class ScreenFormatterFactory(Generic[T]):
 
             row_components = c.children  # Create a widget for each row of Group
             if stacked and any(
-                isinstance(child, SignalRW) and child.read_widget is not None
+                isinstance(child, SignalRW) and isinstance(child.read_widget, TextRead)
                 for child in c.children
             ):
                 component_bounds.h = 2 * self.layout.widget_height + self.layout.spacing
@@ -579,7 +582,7 @@ class ScreenFormatterFactory(Generic[T]):
                     value=rc.value,
                 )
             elif isinstance(rc, SignalRW):
-                if stacked and rc.read_widget:
+                if stacked and isinstance(rc.read_widget, TextRead):
                     top, bottom = rc_bounds.split_into_rows(2, self.layout.spacing)
                     yield from self.generate_write_widget(rc, top)
                     yield from self.generate_read_widget(rc, bottom)

--- a/tests/format/input/stacked.pvi.device.yaml
+++ b/tests/format/input/stacked.pvi.device.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=../../../schemas/pvi.device.schema.json
+
+label: Stacked
+children:
+  - type: Group
+    name: StackedGroup
+    layout:
+      type: Grid
+      stacked: true
+    children:
+      - type: SignalRW
+        name: StackedReadWrite
+        description: An RW with a TextRead widget, so it stacks
+        write_pv: StackedReadWrite
+        read_pv: StackedReadWrite_RBV
+
+      - type: SignalRW
+        name: UnstackedReadWrite
+        description: An RW with a non-TextRead widget, so it does not stack
+        write_pv: UnstackedReadWrite
+        read_pv: UnstackedReadWrite_RBV
+        read_widget:
+          type: LED

--- a/tests/format/output/stacked.bob
+++ b/tests/format/output/stacked.bob
@@ -1,0 +1,93 @@
+<display version="2.0.0">
+  <name>Stacked</name>
+  <x>0</x>
+  <y use_class="true">0</y>
+  <width>290</width>
+  <height>136</height>
+  <grid_step_x>4</grid_step_x>
+  <grid_step_y>4</grid_step_y>
+  <widget type="label" version="2.0.0">
+    <name>Title</name>
+    <class>TITLE</class>
+    <text>Stacked</text>
+    <x use_class="true">0</x>
+    <y use_class="true">0</y>
+    <width>290</width>
+    <height>26</height>
+    <font use_class="true">
+      <font name="Header 1" family="Liberation Sans" style="BOLD" size="22.0">
+      </font>
+    </font>
+    <foreground_color use_class="true">
+      <color name="Text" red="0" green="0" blue="0">
+      </color>
+    </foreground_color>
+    <transparent use_class="true">true</transparent>
+    <horizontal_alignment>1</horizontal_alignment>
+  </widget>
+  <widget type="group" version="2.0.0">
+    <name>Stacked Group</name>
+    <x>4</x>
+    <y>30</y>
+    <width>282</width>
+    <height>102</height>
+    <transparent>true</transparent>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Stacked Read Write</text>
+      <x>0</x>
+      <y>0</y>
+      <width>120</width>
+      <height>44</height>
+      <tooltip>Stacked Read Write - An RW with a TextRead widget, so it stacks</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>StackedReadWrite</pv_name>
+      <x>124</x>
+      <y>0</y>
+      <width>124</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="textupdate" version="2.0.0">
+      <name>TextUpdate</name>
+      <pv_name>StackedReadWrite_RBV</pv_name>
+      <x>124</x>
+      <y>24</y>
+      <width>124</width>
+      <height>20</height>
+      <font>
+        <font name="Default Bold" family="Liberation Sans" style="BOLD" size="14.0">
+      </font>
+      </font>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="label" version="2.0.0">
+      <name>Label</name>
+      <text>Unstacked Read Write</text>
+      <x>0</x>
+      <y>48</y>
+      <width>120</width>
+      <height>20</height>
+      <tooltip>Unstacked Read Write - An RW with a non-TextRead widget, so it does not stack</tooltip>
+    </widget>
+    <widget type="textentry" version="3.0.0">
+      <name>TextEntry</name>
+      <pv_name>UnstackedReadWrite</pv_name>
+      <x>124</x>
+      <y>48</y>
+      <width>60</width>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+    </widget>
+    <widget type="led" version="2.0.0">
+      <name>LED</name>
+      <pv_name>UnstackedReadWrite_RBV</pv_name>
+      <x>208</x>
+      <y>48</y>
+      <width>20</width>
+      <height>20</height>
+    </widget>
+  </widget>
+</display>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,6 +203,21 @@ def test_static_table(tmp_path, helper, input_yaml, formatter, output):
         )
 
 
+def test_stacked(tmp_path, helper):
+    expected_path = HERE / "format" / "output" / "stacked.bob"
+    input_path = HERE / "format" / "input"
+    formatter_path = input_path / "dls.bob.pvi.formatter.yaml"
+    with pytest.deprecated_call():
+        helper.assert_cli_output_matches(
+            app,
+            expected_path,
+            "format --yaml-path " + str(input_path),
+            tmp_path / "stacked.bob",
+            HERE / "format" / "input" / "stacked.pvi.device.yaml",
+            formatter_path,
+        )
+
+
 @pytest.mark.parametrize(
     "formatter,format,skip",
     [


### PR DESCRIPTION
Test all widgets in and out of Tables when stacked and not:

<img width="901" height="843" alt="Screenshot from 2026-06-02 09-57-06" src="https://github.com/user-attachments/assets/4fe1c918-9d1a-425c-90e6-9158adb33797" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced layout rendering for stacked read/write signal widgets, improving widget composition and visual alignment.

* **Tests**
  * Added test fixtures and regression tests validating both stacked and unstacked widget layout configurations with different display component types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->