### PR TITLE
feat: allow dynamic includes

### DIFF
--- a/schemas/pvi.device.schema.json
+++ b/schemas/pvi.device.schema.json
@@ -490,6 +490,12 @@
           "title": "In Subscreen",
           "type": "boolean"
         },
+        "dynamic": {
+          "default": false,
+          "description": "Defines if device will be dynamically generated",
+          "title": "Dynamic",
+          "type": "boolean"
+        },
         "type": {
           "const": "Include",
           "default": "Include",

--- a/src/pvi/device.py
+++ b/src/pvi/device.py
@@ -500,6 +500,9 @@ class Include(TypedModel):
         bool,
         Field(description="Include components in a SubScreen, or flatten."),
     ] = False
+    dynamic: Annotated[
+        bool, Field(description="Defines if device will be dynamically generated")
+    ] = False
 
 
 Tree = Sequence[ComponentUnion | Include]
@@ -532,6 +535,7 @@ class Device(TypedModel, YamlValidatorMixin):
         ),
     ] = None
     children: Annotated[Tree, Field(description="Child Components")] = []
+    _dynamic_children: dict[int, str] = {}
 
     def _to_dict(self) -> dict[str, Any]:
         """Serialize a `Device` instance to a `dict`.
@@ -590,7 +594,9 @@ class Device(TypedModel, YamlValidatorMixin):
         components: Tree = []
         for component in self.children:
             if isinstance(component, Include):
-                expanded_components = self.expand_includes(component, yaml_paths)
+                expanded_components = self.expand_includes(
+                    component, yaml_paths, len(components)
+                )
                 components.extend(expanded_components)
             else:
                 components.append(component)
@@ -599,15 +605,28 @@ class Device(TypedModel, YamlValidatorMixin):
         pass
 
     def expand_includes(
-        self, component: Include, yaml_paths: list[Path]
+        self, component: Include, yaml_paths: list[Path], base_index: int = 0
     ) -> list[ComponentUnion]:
         resolved: list[ComponentUnion] = []
-        include_components = find_components(component.file_name, yaml_paths)
+        if component.dynamic:
+            # Track this dynamic include at its position in final components list
+            self._dynamic_children[base_index] = component.file_name
+            # Temporarily ignore the dynamic include
+            include_components = [IgnoredComponent(name=component.file_name)]
+        else:
+            include_components = find_components(component.file_name, yaml_paths)
+
+        current_index = base_index
         for new_component in include_components:
             if isinstance(new_component, Include):
-                resolved.extend(self.expand_includes(new_component, yaml_paths))
+                expanded = self.expand_includes(
+                    new_component, yaml_paths, current_index
+                )
+                resolved.extend(expanded)
+                current_index += len(expanded)
             else:
                 resolved.append(new_component)
+                current_index += 1
 
         if component.in_subscreen:
             resolved = [
@@ -668,6 +687,19 @@ class Device(TypedModel, YamlValidatorMixin):
                 group.children = merged_children + list(new_children.values())
 
         self.children = merged
+
+    def resolve_dynamic_children(self, yaml_paths: list[Path]):
+        resolved: Tree = []
+        for index, child in enumerate(self.children):
+            if name := self._dynamic_children.get(index):
+                if find_pvi_yaml(f"{name}.pvi.device.yaml", yaml_paths):
+                    resolved.extend(
+                        self.expand_includes(Include(file_name=name), yaml_paths)
+                    )
+                    continue  # Skip dynamic include, leaving it as an IgnoredComponent
+            resolved.append(child)
+
+        self.children = resolved
 
     def generate_param_tree(self) -> str:
         param_tree = ", ".join(

--- a/tests/convert/output/Mako125B.pvi.device.yaml
+++ b/tests/convert/output/Mako125B.pvi.device.yaml
@@ -49,3 +49,4 @@ children:
   - type: Include
     file_name: GenICamDriver
     in_subscreen: false
+    dynamic: false

--- a/tests/convert/output/simDetector.pvi.device.yaml
+++ b/tests/convert/output/simDetector.pvi.device.yaml
@@ -323,3 +323,4 @@ children:
   - type: Include
     file_name: ADDriver
     in_subscreen: false
+    dynamic: false

--- a/tests/reconvert/output/simDetector.pvi.device.yaml
+++ b/tests/reconvert/output/simDetector.pvi.device.yaml
@@ -332,6 +332,7 @@ children:
   - type: Include
     file_name: ADDriver
     in_subscreen: false
+    dynamic: false
 
   - type: Group
     name: SimDetectorExtra

--- a/tests/test.pvi.device.yaml
+++ b/tests/test.pvi.device.yaml
@@ -43,3 +43,4 @@ children:
   - type: Include
     file_name: parent
     in_subscreen: false
+    dynamic: false

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,8 @@ from pvi.device import (
     DeviceRef,
     Grid,
     Group,
+    IgnoredComponent,
+    Include,
     SignalR,
     SignalRW,
     SignalW,
@@ -178,6 +180,49 @@ def test_device_ref(tmp_path, helper):
     formatter.format(device, output_bob)
 
     helper.assert_output_matches(expected_bob, output_bob)
+
+
+def test_dynamic_include_resolves(tmp_path):
+    grandchild = Device(
+        label="GrandChildDevice",
+        children=[
+            SignalR(
+                name="GrandChildSignal",
+                read_pv="GRANDCHILD:PV",
+                read_widget=TextRead(),
+            )
+        ],
+    )
+
+    # Set up file name, but don't serialize yet.
+    grandchild_file = tmp_path / "GrandChildDevice.pvi.device.yaml"
+    grandchild.serialize(grandchild_file)
+
+    child = Device(
+        label="ChildDevice",
+        children=[Include(file_name="GrandChildDevice", dynamic=True)],
+    )
+    child_file = tmp_path / "ChildDevice.pvi.device.yaml"
+    child.serialize(child_file)
+
+    parent = Device(
+        label="ParentDevice", children=[Include(file_name="ChildDevice", dynamic=False)]
+    )
+
+    with pytest.deprecated_call():
+        parent.deserialize_parents([tmp_path])
+
+    assert parent._dynamic_children == {0: "GrandChildDevice"}
+    assert len(parent.children) == 1
+    assert parent.children[0] == IgnoredComponent(name="GrandChildDevice")
+
+    grandchild.serialize(grandchild_file)
+    with pytest.deprecated_call():
+        parent.resolve_dynamic_children([tmp_path])
+
+    assert len(parent.children) == 1
+    assert isinstance(parent.children[0], SignalR)
+    assert parent.children[0].name == "GrandChildSignal"
 
 
 def test_group_sub_screen(tmp_path, helper):


### PR DESCRIPTION
This PR allows `Include` components to be set to `dynamic=True`, wherein they may be resolved after ibek generation of sub-entities.

Defining:
```yaml
  - type: Include
    file_name: parent
    dynamic: true
```
stores the position of this include, and replaces it with an `IgnoredComponent`. Upon calling `resolve_dynamic_children`, if a serialized `parent.pvi.device.yaml` this is replaces with a `dynamic=false` `Include` and expanded, otherwise it is left as an `IgnoredComponent`.

This is related to this ibek [PR](https://github.com/epics-containers/ibek/pull/350)