### PR TITLE
Append before ext

### DIFF
--- a/src/pvi/_format/dls.py
+++ b/src/pvi/_format/dls.py
@@ -27,7 +27,7 @@ from pvi._format.widget import (
 from pvi.device import Device
 
 from .base import Formatter
-from .utils import Bounds, with_title
+from .utils import Bounds, split_base_and_ext, with_title
 
 
 class DLSFormatter(Formatter):
@@ -177,6 +177,8 @@ class DLSFormatter(Formatter):
                 )
             ]
 
+        base_file_name, all_suffixes = split_base_and_ext(path)
+
         formatter_factory: ScreenFormatterFactory[str] = ScreenFormatterFactory(
             screen_formatter_cls=GroupFormatter[str].from_template(
                 template,
@@ -195,7 +197,7 @@ class DLSFormatter(Formatter):
             ),
             widget_formatter_factory=widget_formatter_factory,
             layout=screen_layout,
-            base_file_name=path.stem,
+            base_file_name=base_file_name,
         )
         title = f"{device.label}"
 
@@ -205,7 +207,7 @@ class DLSFormatter(Formatter):
 
         path.write_text("".join(screen_formatter.format()))
         for sub_screen_name, sub_screen_formatter in sub_screens:
-            sub_screen_path = Path(path.parent / f"{sub_screen_name}{path.suffix}")
+            sub_screen_path = Path(path.parent / f"{sub_screen_name}{all_suffixes}")
             sub_screen_path.write_text("".join(sub_screen_formatter.format()))
 
     def format_bob(self, device: Device, path: Path):
@@ -352,6 +354,8 @@ class DLSFormatter(Formatter):
                 )
             ]
 
+        base_file_name, all_suffixes = split_base_and_ext(path)
+
         # SCREEN_INI DOCS REF: Construct a screen object
         formatter_factory: ScreenFormatterFactory[_Element] = ScreenFormatterFactory(
             screen_formatter_cls=GroupFormatter[_Element].from_template(
@@ -370,7 +374,7 @@ class DLSFormatter(Formatter):
             ),
             widget_formatter_factory=widget_formatter_factory,
             layout=screen_layout,
-            base_file_name=path.stem,
+            base_file_name=base_file_name,
         )
         # SCREEN_FORMAT DOCS REF: Format the screen
         title = f"{device.label}"
@@ -381,7 +385,7 @@ class DLSFormatter(Formatter):
 
         write_bob(screen_formatter, path)
         for sub_screen_name, sub_screen_formatter in sub_screens:
-            sub_screen_path = Path(path.parent / f"{sub_screen_name}{path.suffix}")
+            sub_screen_path = Path(path.parent / f"{sub_screen_name}{all_suffixes}")
             write_bob(sub_screen_formatter, sub_screen_path)
 
 

--- a/src/pvi/_format/utils.py
+++ b/src/pvi/_format/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import TypeVar
 
 from pydantic import BaseModel
@@ -99,3 +100,10 @@ def with_title(spacing: int, title_height: int) -> Callable[[Bounds], Bounds]:
     return Bounds(
         x=spacing, y=spacing + title_height, w=2 * spacing, h=2 * spacing + title_height
     ).added_to
+
+
+def split_base_and_ext(path: Path) -> tuple[str, str]:
+    """Split a filename into its base name and full extension chain."""
+    base, sep, ext = path.name.partition(".")
+
+    return base, f"{sep}{ext}" if sep else ""


### PR DESCRIPTION
To fix this bug with output bob files when there are mutliple suffixes (.pvi.bob):

```
NDROI.pvi.bob
NDROI.pvi_Advanced.bob
...
```

which should now be 

```
NDROI.pvi.bob
NDROI_Advanced.pvi.bob
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file extension handling in screen format generation to more accurately process complex filenames during format conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->