### PR TITLE
Add AsynInt64Waveform and AsynFloat32Waveform parameter types

### DIFF
--- a/src/pvi/_convert/_asyn_convert.py
+++ b/src/pvi/_convert/_asyn_convert.py
@@ -223,6 +223,30 @@ class AsynInt32Waveform(AsynWaveform):
     write_widget: WriteWidgetUnion = TextWrite()
 
 
+class AsynInt64Waveform(AsynWaveform):
+    """Asyn Waveform Parameter and records with int64 array elements"""
+
+    type_strings: ClassVar[TypeStrings] = TypeStrings(
+        asyn_read="asynInt64ArrayIn",
+        asyn_write="asynInt64ArrayOut",
+        asyn_param="asynParamInt64",
+    )
+    read_widget: ReadWidgetUnion = TextRead()
+    write_widget: WriteWidgetUnion = TextWrite()
+
+
+class AsynFloat32Waveform(AsynWaveform):
+    """Asyn Waveform Parameter and records with float32 array elements"""
+
+    type_strings: ClassVar[TypeStrings] = TypeStrings(
+        asyn_read="asynFloat32ArrayIn",
+        asyn_write="asynFloat32ArrayOut",
+        asyn_param="asynParamFloat32",
+    )
+    read_widget: ReadWidgetUnion = TextRead()
+    write_widget: WriteWidgetUnion = TextWrite()
+
+
 class AsynFloat64Waveform(AsynWaveform):
     """Asyn Waveform Parameter and records with float64 array elements"""
 

--- a/tests/test_asyn_convert.py
+++ b/tests/test_asyn_convert.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pvi._convert._asyn_convert import (
+    AsynFloat32Waveform,
+    AsynFloat64Waveform,
+    AsynInt32Waveform,
+    AsynInt64Waveform,
+    AsynWaveform,
+    get_waveform_parameter,
+)
+
+
+@pytest.mark.parametrize(
+    "dtyp,expected",
+    [
+        ("asynOctetRead", AsynWaveform),
+        ("asynOctetWrite", AsynWaveform),
+        ("asynInt32ArrayIn", AsynInt32Waveform),
+        ("asynInt32ArrayOut", AsynInt32Waveform),
+        ("asynInt64ArrayIn", AsynInt64Waveform),
+        ("asynInt64ArrayOut", AsynInt64Waveform),
+        ("asynFloat32ArrayIn", AsynFloat32Waveform),
+        ("asynFloat32ArrayOut", AsynFloat32Waveform),
+        ("asynFloat64ArrayIn", AsynFloat64Waveform),
+        ("asynFloat64ArrayOut", AsynFloat64Waveform),
+    ],
+)
+def test_get_waveform_parameter(dtyp, expected):
+    assert get_waveform_parameter(dtyp) is expected
+
+
+def test_get_waveform_parameter_unknown_raises():
+    with pytest.raises(AssertionError, match="asynUnknown"):
+        get_waveform_parameter("asynUnknown")


### PR DESCRIPTION
Support some other asyn waveform types which are found in epics databases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional waveform array types, including 64-bit integer and 32-bit floating-point values.
  * These waveform fields now use text-based read and write widgets for easier viewing and editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->