### PR TITLE
Fix regroup to preserve Include nodes unchanged

### DIFF
--- a/src/pvi/_pv_group.py
+++ b/src/pvi/_pv_group.py
@@ -6,6 +6,7 @@ from pvi.device import (
     Device,
     Grid,
     Group,
+    Include,
     Tree,
     enforce_pascal_case,
     walk,
@@ -59,7 +60,21 @@ def find_pvs(pvs: list[str], file_path: Path) -> tuple[list[str], list[str]]:
 
 
 def group_by_ui(device: Device, ui_paths: list[Path]) -> Tree:
-    signals: list[ComponentUnion] = list(walk(device.children))
+    """Group the device parameters by the UI files they are found in
+    Args:
+        device: The device containing the parameters to group.
+        ui_paths: A list of paths to the UI files to search for PVs.
+
+    Returns:
+        A tree structure with parameters grouped by the UI files they are found in.
+    """
+
+    # Separate the Include nodes from the rest of the device children
+    # so that they can be passed through to the UI tree without modification
+    includes = [c for c in device.children if isinstance(c, Include)]
+    signals: list[ComponentUnion] = list(
+        walk([c for c in device.children if not isinstance(c, Include)])
+    )
 
     # PVs without macros to search for in UI
     pv_names = [s.name for s in signals]
@@ -104,4 +119,4 @@ def group_by_ui(device: Device, ui_paths: list[Path]) -> Tree:
             )
         )
 
-    return ui_groups
+    return ui_groups + includes  # preserve Include nodes at end

--- a/tests/regroup/input/detector.adl
+++ b/tests/regroup/input/detector.adl
@@ -1,0 +1,22 @@
+text_monitor {
+    object {
+        x=10
+        y=30
+        width=100
+        height=20
+    }
+    monitor {
+        chan="Gain"
+    }
+}
+text_entry {
+    object {
+        x=10
+        y=60
+        width=100
+        height=20
+    }
+    control {
+        chan="Offset"
+    }
+}

--- a/tests/regroup/input/regroup_with_include.pvi.device.yaml
+++ b/tests/regroup/input/regroup_with_include.pvi.device.yaml
@@ -1,0 +1,23 @@
+label: detector
+children:
+  - type: SignalRW
+    name: Gain
+    write_pv: $(P)$(R)Gain
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)Gain_RBV
+    read_widget:
+      type: TextRead
+
+  - type: SignalRW
+    name: Offset
+    write_pv: $(P)$(R)Offset
+    write_widget:
+      type: TextWrite
+    read_pv: $(P)$(R)Offset_RBV
+    read_widget:
+      type: TextRead
+
+  - type: Include
+    file_name: ADBase
+    in_subscreen: false

--- a/tests/regroup/output/regroup_with_include.pvi.device.yaml
+++ b/tests/regroup/output/regroup_with_include.pvi.device.yaml
@@ -1,0 +1,31 @@
+label: detector
+children:
+  - type: Group
+    name: Detector
+    label: detector
+    layout:
+      type: Grid
+      labelled: true
+      stacked: false
+    children:
+      - type: SignalRW
+        name: Gain
+        write_pv: $(P)$(R)Gain
+        write_widget:
+          type: TextWrite
+        read_pv: $(P)$(R)Gain_RBV
+        read_widget:
+          type: TextRead
+
+      - type: SignalRW
+        name: Offset
+        write_pv: $(P)$(R)Offset
+        write_widget:
+          type: TextWrite
+        read_pv: $(P)$(R)Offset_RBV
+        read_widget:
+          type: TextRead
+
+  - type: Include
+    file_name: ADBase
+    in_subscreen: false

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,22 @@ def test_reconvert(tmp_path, helper):
     )
 
 
+def test_regroup_preserves_includes(tmp_path, helper):
+    """Regroup should skip Include nodes and pass them through unchanged."""
+    expected_path = HERE / "regroup" / "output"
+    input_path = HERE / "regroup" / "input"
+    filename = "regroup_with_include.pvi.device.yaml"
+    # Make a copy because regroup modifies the file in place
+    shutil.copy(input_path / filename, tmp_path / filename)
+    helper.assert_cli_output_matches(
+        app,
+        expected_path / filename,
+        "regroup",
+        tmp_path / filename,
+        input_path / "detector.adl",
+    )
+
+
 @pytest.mark.parametrize(
     "input_yaml,formatter,output",
     [


### PR DESCRIPTION
pvi regroup walks all signals and reorganises them into Groups based on ADL file positions. Include nodes are not signals — they are opaque references to another device's already-organised signal tree. Walking or flattening them would produce wrong output.

Changes:
- group_by_ui() now separates Include nodes before calling walk(), which raises TypeError on Include. After grouping, Includes are appended to the end of the output tree unchanged.
- Add test_regroup_preserves_includes: a device with two signals and one Include node is regrouped; the test asserts that the Include appears unchanged in the output alongside the newly-formed Group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Regrouping now preserves existing include entries instead of dropping them, keeping generated device layouts complete.
  * Improved grouping behavior so included content stays attached at the end of the regrouped output.

* **Tests**
  * Added coverage for regrouping devices that contain include directives to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->